### PR TITLE
Add walls and flying pathfinding demo

### DIFF
--- a/command_line_conflict/engine.py
+++ b/command_line_conflict/engine.py
@@ -1,8 +1,8 @@
 import pygame
 
 from . import config
-from .units import Airplane
 from .maps import Map, SimpleMap
+from .units import Airplane
 
 
 class Game:
@@ -10,7 +10,9 @@ class Game:
 
     def __init__(self, game_map: Map | None = None) -> None:
         pygame.init()
-        self.screen = pygame.display.set_mode((config.SCREEN_WIDTH, config.SCREEN_HEIGHT))
+        self.screen = pygame.display.set_mode(
+            (config.SCREEN_WIDTH, config.SCREEN_HEIGHT)
+        )
         pygame.display.set_caption("ASCII RTS")
         self.clock = pygame.time.Clock()
         self.font = pygame.font.SysFont("monospace", 16)
@@ -46,8 +48,7 @@ class Game:
             grid_y = event.pos[1] // config.GRID_SIZE
             for u in self.map.units:
                 if u.selected:
-                    u.target_x = grid_x
-                    u.target_y = grid_y
+                    u.set_target(grid_x, grid_y, self.map)
         elif event.type == pygame.KEYDOWN and event.key == pygame.K_a:
             mx, my = pygame.mouse.get_pos()
             gx = mx // config.GRID_SIZE
@@ -61,10 +62,15 @@ class Game:
         self.screen.fill((0, 0, 0))
 
         for x in range(0, config.SCREEN_WIDTH, config.GRID_SIZE):
-            pygame.draw.line(self.screen, (40, 40, 40), (x, 0), (x, config.SCREEN_HEIGHT))
+            pygame.draw.line(
+                self.screen, (40, 40, 40), (x, 0), (x, config.SCREEN_HEIGHT)
+            )
         for y in range(0, config.SCREEN_HEIGHT, config.GRID_SIZE):
-            pygame.draw.line(self.screen, (40, 40, 40), (0, y), (config.SCREEN_WIDTH, y))
+            pygame.draw.line(
+                self.screen, (40, 40, 40), (0, y), (config.SCREEN_WIDTH, y)
+            )
 
+        self.map.draw(self.screen, self.font)
         for u in self.map.units:
             u.draw(self.screen, self.font)
 

--- a/command_line_conflict/maps/__init__.py
+++ b/command_line_conflict/maps/__init__.py
@@ -1,4 +1,5 @@
 from .base import Map
 from .simple_map import SimpleMap
+from .wall_map import WallMap
 
-__all__ = ["Map", "SimpleMap"]
+__all__ = ["Map", "SimpleMap", "WallMap"]

--- a/command_line_conflict/maps/base.py
+++ b/command_line_conflict/maps/base.py
@@ -1,17 +1,70 @@
-from typing import List
+from heapq import heappop, heappush
+from typing import Dict, List, Tuple
 
+from .. import config
 from ..units import Unit
 
 
 class Map:
     """Container for units present in a level."""
 
-    def __init__(self) -> None:
+    def __init__(self, width: int = 40, height: int = 30) -> None:
+        self.width = width
+        self.height = height
         self.units: List[Unit] = []
+        self.walls: set[Tuple[int, int]] = set()
 
     def spawn_unit(self, unit: Unit) -> None:
         self.units.append(unit)
 
+    def add_wall(self, x: int, y: int) -> None:
+        self.walls.add((x, y))
+
+    def is_blocked(self, x: int, y: int) -> bool:
+        return (x, y) in self.walls
+
+    def find_path(
+        self, start: Tuple[int, int], goal: Tuple[int, int]
+    ) -> List[Tuple[int, int]]:
+        """A* pathfinding ignoring dynamic obstacles."""
+        if self.is_blocked(*goal):
+            return []
+
+        open_set: List[Tuple[int, Tuple[int, int]]] = []
+        heappush(open_set, (0, start))
+        came_from: Dict[Tuple[int, int], Tuple[int, int]] = {}
+        g_score = {start: 0}
+
+        while open_set:
+            _, current = heappop(open_set)
+            if current == goal:
+                path = []
+                while current != start:
+                    path.append(current)
+                    current = came_from[current]
+                path.reverse()
+                return path
+
+            for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+                nx, ny = current[0] + dx, current[1] + dy
+                if not (0 <= nx < self.width and 0 <= ny < self.height):
+                    continue
+                if self.is_blocked(nx, ny):
+                    continue
+                tentative_g = g_score[current] + 1
+                if (nx, ny) not in g_score or tentative_g < g_score[(nx, ny)]:
+                    g_score[(nx, ny)] = tentative_g
+                    f = tentative_g + abs(nx - goal[0]) + abs(ny - goal[1])
+                    heappush(open_set, (f, (nx, ny)))
+                    came_from[(nx, ny)] = current
+
+        return []
+
     def update(self, dt: float) -> None:
         for u in list(self.units):
-            u.update(dt)
+            u.update(dt, self)
+
+    def draw(self, surf, font) -> None:
+        for x, y in self.walls:
+            ch = font.render("#", True, (100, 100, 100))
+            surf.blit(ch, (x * config.GRID_SIZE, y * config.GRID_SIZE))

--- a/command_line_conflict/maps/simple_map.py
+++ b/command_line_conflict/maps/simple_map.py
@@ -1,5 +1,5 @@
+from ..units import Airplane, Marine, Tank
 from .base import Map
-from ..units import Unit, Airplane
 
 
 class SimpleMap(Map):
@@ -7,6 +7,6 @@ class SimpleMap(Map):
 
     def __init__(self) -> None:
         super().__init__()
-        self.spawn_unit(Unit(5, 5))
-        self.spawn_unit(Unit(10, 10))
+        self.spawn_unit(Marine(5, 5))
+        self.spawn_unit(Tank(10, 10))
         self.spawn_unit(Airplane(15, 5))

--- a/command_line_conflict/maps/wall_map.py
+++ b/command_line_conflict/maps/wall_map.py
@@ -1,0 +1,17 @@
+from ..units import Airplane, Marine, Tank
+from .base import Map
+
+
+class WallMap(Map):
+    """Small map with walls to demonstrate pathfinding."""
+
+    def __init__(self) -> None:
+        super().__init__(width=20, height=15)
+        # create a simple horizontal wall with a gap
+        for x in range(3, 17):
+            if x != 10:
+                self.add_wall(x, 7)
+
+        self.spawn_unit(Marine(1, 1))
+        self.spawn_unit(Tank(2, 2))
+        self.spawn_unit(Airplane(4, 1))

--- a/command_line_conflict/units/__init__.py
+++ b/command_line_conflict/units/__init__.py
@@ -1,4 +1,15 @@
-from .base import Unit
+from .air_units import Helicopter, Jet
 from .airplane import Airplane
+from .base import AirUnit, GroundUnit, Unit
+from .ground_units import Marine, Tank
 
-__all__ = ["Unit", "Airplane"]
+__all__ = [
+    "Unit",
+    "GroundUnit",
+    "AirUnit",
+    "Marine",
+    "Tank",
+    "Airplane",
+    "Helicopter",
+    "Jet",
+]

--- a/command_line_conflict/units/air_units.py
+++ b/command_line_conflict/units/air_units.py
@@ -1,0 +1,9 @@
+from .base import AirUnit
+
+
+class Helicopter(AirUnit):
+    icon = "H"
+
+
+class Jet(AirUnit):
+    icon = "J"

--- a/command_line_conflict/units/airplane.py
+++ b/command_line_conflict/units/airplane.py
@@ -1,11 +1,13 @@
 from .. import config
-from .base import Unit
+from .base import AirUnit
 
 
-class Airplane(Unit):
-    """Example of a different type of Unit."""
+class Airplane(AirUnit):
+    """Simple flying unit."""
+
+    icon = "A"
 
     def draw(self, surf, font) -> None:
         color = (0, 255, 255) if self.selected else (200, 200, 200)
-        ch = font.render("A", True, color)
+        ch = font.render(self.icon, True, color)
         surf.blit(ch, (int(self.x) * config.GRID_SIZE, int(self.y) * config.GRID_SIZE))

--- a/command_line_conflict/units/base.py
+++ b/command_line_conflict/units/base.py
@@ -2,7 +2,9 @@ from .. import config
 
 
 class Unit:
-    """A basic unit that can move around the grid."""
+    """Base unit class."""
+
+    icon = "U"
 
     def __init__(self, x: float, y: float) -> None:
         self.x = float(x)
@@ -10,8 +12,17 @@ class Unit:
         self.target_x = self.x
         self.target_y = self.y
         self.selected = False
+        self.path: list[tuple[int, int]] = []
 
-    def update(self, dt: float) -> None:
+    def is_air(self) -> bool:  # pragma: no cover - tiny helper
+        return False
+
+    def set_target(self, x: int, y: int, game_map=None) -> None:
+        self.target_x = x
+        self.target_y = y
+        self.path = []
+
+    def update(self, dt: float, game_map=None) -> None:
         """Move the unit toward its target."""
         dx = self.target_x - self.x
         dy = self.target_y - self.y
@@ -26,5 +37,46 @@ class Unit:
 
     def draw(self, surf, font) -> None:
         color = (0, 255, 0) if self.selected else (255, 255, 255)
-        ch = font.render("U", True, color)
+        ch = font.render(self.icon, True, color)
         surf.blit(ch, (int(self.x) * config.GRID_SIZE, int(self.y) * config.GRID_SIZE))
+
+
+class GroundUnit(Unit):
+    """Unit that uses pathfinding and cannot cross walls."""
+
+    icon = "G"
+
+    def set_target(self, x: int, y: int, game_map=None) -> None:
+        super().set_target(x, y, game_map)
+        if game_map:
+            sx, sy = int(self.x), int(self.y)
+            self.path = game_map.find_path((sx, sy), (x, y))
+
+    def update(self, dt: float, game_map=None) -> None:
+        if self.path:
+            next_x, next_y = self.path[0]
+            self.target_x, self.target_y = next_x, next_y
+            dx = self.target_x - self.x
+            dy = self.target_y - self.y
+            dist = (dx * dx + dy * dy) ** 0.5
+            if dist < 0.01:
+                self.x = self.target_x
+                self.y = self.target_y
+                self.path.pop(0)
+            else:
+                step = config.UNIT_SPEED * dt
+                if step > dist:
+                    step = dist
+                self.x += step * dx / dist
+                self.y += step * dy / dist
+        else:
+            super().update(dt, game_map)
+
+
+class AirUnit(Unit):
+    """Unit that can fly over walls."""
+
+    icon = "A"
+
+    def is_air(self) -> bool:  # pragma: no cover - simple helper
+        return True

--- a/command_line_conflict/units/ground_units.py
+++ b/command_line_conflict/units/ground_units.py
@@ -1,0 +1,9 @@
+from .base import GroundUnit
+
+
+class Marine(GroundUnit):
+    icon = "M"
+
+
+class Tank(GroundUnit):
+    icon = "T"

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from command_line_conflict.engine import main
-from command_line_conflict.maps import SimpleMap
+from command_line_conflict.maps import WallMap
 
 if __name__ == "__main__":
-    main(SimpleMap())
+    main(WallMap())


### PR DESCRIPTION
## Summary
- implement wall support and A* pathfinding for ground units
- introduce `GroundUnit` and `AirUnit` abstractions
- add Marine, Tank, Helicopter, Jet unit classes
- create `WallMap` demo with a row of walls
- update engine to route ground units around walls
- default `main.py` runs the new `WallMap`

## Testing
- `isort . --check-only`
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860d864f91c83218757b8aa28a3e947