### PR TITLE
Add move paths and improve unit selection

### DIFF
--- a/command_line_conflict/engine.py
+++ b/command_line_conflict/engine.py
@@ -36,12 +36,14 @@ class Game:
             x1, y1 = self.selection_start
             x2, y2 = event.pos
             self.selection_start = None
-            min_x, max_x = sorted((x1, x2))
-            min_y, max_y = sorted((y1, y2))
+
+            sx, ex = sorted((x1 // config.GRID_SIZE, x2 // config.GRID_SIZE))
+            sy, ey = sorted((y1 // config.GRID_SIZE, y2 // config.GRID_SIZE))
+
             for u in self.map.units:
-                ux = u.x * config.GRID_SIZE
-                uy = u.y * config.GRID_SIZE
-                if min_x <= ux <= max_x and min_y <= uy <= max_y:
+                ux = int(u.x)
+                uy = int(u.y)
+                if sx <= ux <= ex and sy <= uy <= ey:
                     u.selected = True
         elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 3:
             grid_x = event.pos[0] // config.GRID_SIZE

--- a/command_line_conflict/units/airplane.py
+++ b/command_line_conflict/units/airplane.py
@@ -10,4 +10,11 @@ class Airplane(AirUnit):
     def draw(self, surf, font) -> None:
         color = (0, 255, 255) if self.selected else (200, 200, 200)
         ch = font.render(self.icon, True, color)
-        surf.blit(ch, (int(self.x) * config.GRID_SIZE, int(self.y) * config.GRID_SIZE))
+        surf.blit(
+            ch,
+            (
+                int(self.x) * config.GRID_SIZE,
+                int(self.y) * config.GRID_SIZE,
+            ),
+        )
+        self.draw_orders(surf, font)

--- a/command_line_conflict/units/base.py
+++ b/command_line_conflict/units/base.py
@@ -38,7 +38,41 @@ class Unit:
     def draw(self, surf, font) -> None:
         color = (0, 255, 0) if self.selected else (255, 255, 255)
         ch = font.render(self.icon, True, color)
-        surf.blit(ch, (int(self.x) * config.GRID_SIZE, int(self.y) * config.GRID_SIZE))
+        surf.blit(
+            ch,
+            (
+                int(self.x) * config.GRID_SIZE,
+                int(self.y) * config.GRID_SIZE,
+            ),
+        )
+
+        self.draw_orders(surf, font)
+
+    def draw_orders(self, surf, font) -> None:
+        """Render target point and remaining path when selected."""
+        if not self.selected:
+            return
+
+        final = (int(self.target_x), int(self.target_y))
+
+        # If the unit has arrived and has no path, nothing to draw
+        if not self.path and final == (int(self.x), int(self.y)):
+            return
+
+        # Combine remaining path with final destination
+        tiles = list(self.path)
+        if not tiles or tiles[-1] != final:
+            tiles.append(final)
+
+        # draw intermediate path tiles
+        for tx, ty in tiles[:-1]:
+            ch = font.render("\u2591", True, (0, 255, 0))
+            surf.blit(ch, (tx * config.GRID_SIZE, ty * config.GRID_SIZE))
+
+        # draw final destination
+        tx, ty = tiles[-1]
+        ch = font.render("\u2588", True, (255, 0, 0))
+        surf.blit(ch, (tx * config.GRID_SIZE, ty * config.GRID_SIZE))
 
 
 class GroundUnit(Unit):


### PR DESCRIPTION
## Summary
- allow single tile selection when dragging or clicking
- render remaining move paths and final destination for selected units
- show these move visuals for both ground and air units

## Testing
- `black --check .`
- `isort --check-only .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861de77acb883218108584d6dbf6047