### PR TITLE
Improve fallback fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ pyinstaller --onefile main.py
 
 The current prototype lets you left-click and drag to select units and right-click to command them to move on the grid. Press **A** while hovering the mouse over a tile to spawn a new airplane unit.
 
+### Font Support
+Unit movement paths use Unicode arrow characters. The engine will try to load
+**DejaVu Sans Mono** first and then fall back to common system monospace fonts
+like **Courier New**. These fonts ship with Windows 10 and recent macOS
+releases. If you see empty blocks instead of arrows, install a font containing
+these glyphs (e.g. DejaVu Sans Mono) and make sure Pygame can locate it.
+
 ## Project Structure
 The source code now lives in a package with a dedicated module for units so
 additional unit types can be added easily.

--- a/command_line_conflict/engine.py
+++ b/command_line_conflict/engine.py
@@ -15,7 +15,26 @@ class Game:
         )
         pygame.display.set_caption("ASCII RTS")
         self.clock = pygame.time.Clock()
-        self.font = pygame.font.SysFont("monospace", 16)
+
+        # Use a font that supports Unicode arrows for path rendering.
+        candidates = [
+            "dejavusansmono",  # bundled with many Linux distros
+            "couriernew",      # available on Windows and macOS
+            "menlo",           # default monospace on macOS
+            "consolas",        # common on Windows
+        ]
+
+        font_path = None
+        for name in candidates:
+            font_path = pygame.font.match_font(name)
+            if font_path:
+                break
+
+        if font_path:
+            self.font = pygame.font.Font(font_path, 16)
+        else:
+            # Fall back to the generic monospace font
+            self.font = pygame.font.SysFont("monospace", 16)
 
         self.map = game_map or SimpleMap()
         self.selection_start = None


### PR DESCRIPTION
## Summary
- search for common monospaced fonts before falling back
- document how font loading works so Unicode arrows render correctly

## Testing
- `python -m py_compile command_line_conflict/*.py command_line_conflict/maps/*.py command_line_conflict/units/*.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6861e994a48883218fe4441a09ec3985