### PR TITLE
Use bundled DejaVu font with ASCII fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ pyinstaller --onefile main.py
 The current prototype lets you left-click and drag to select units and right-click to command them to move on the grid. Press **A** while hovering the mouse over a tile to spawn a new airplane unit.
 
 ### Font Support
-Unit movement paths use Unicode arrow characters. The engine will try to load
-**DejaVu Sans Mono** first and then fall back to common system monospace fonts
-like **Courier New**. These fonts ship with Windows 10 and recent macOS
-releases. If you see empty blocks instead of arrows, install a font containing
-these glyphs (e.g. DejaVu Sans Mono) and make sure Pygame can locate it.
+Unit movement paths use Unicode arrow characters. The engine now bundles
+**DejaVu Sans Mono** and attempts to load it on startup. If that fails, it tries
+common system monospace fonts like **Courier New** and finally falls back to the
+default monospace font with ASCII graphics. If you see placeholder blocks
+instead of arrows, ensure the DejaVu font can be loaded or rely on the ASCII
+fallback.
 
 ## Project Structure
 The source code now lives in a package with a dedicated module for units so

--- a/command_line_conflict/units/base.py
+++ b/command_line_conflict/units/base.py
@@ -1,5 +1,8 @@
 from .. import config
 
+# Flag toggled by the engine to decide whether ASCII graphics should be used
+USE_ASCII = False
+
 
 class Unit:
     """Base unit class."""
@@ -72,23 +75,55 @@ class Unit:
             surf.blit(ch, (tx * config.GRID_SIZE, ty * config.GRID_SIZE))
             prev_x, prev_y = tx, ty
 
-        # draw final destination as a solid block
+        # draw final destination
         tx, ty = tiles[-1]
-        ch = font.render("\u2588", True, (255, 0, 0))
+        final_char = "X" if USE_ASCII else "\u2588"
+        ch = font.render(final_char, True, (255, 0, 0))
         surf.blit(ch, (tx * config.GRID_SIZE, ty * config.GRID_SIZE))
 
     @staticmethod
     def _arrow_char(dx: int, dy: int) -> str:
-        """Return an arrow character for the given direction."""
-        if dx == 1 and dy == 0:
-            return "\u2192"  # right arrow
-        if dx == -1 and dy == 0:
-            return "\u2190"  # left arrow
-        if dx == 0 and dy == 1:
-            return "\u2193"  # down arrow
-        if dx == 0 and dy == -1:
-            return "\u2191"  # up arrow
-        return "+"
+        """Return a character representing movement direction."""
+        if USE_ASCII:
+            if dx == 1 and dy == 0:
+                return ">"
+            if dx == -1 and dy == 0:
+                return "<"
+            if dx == 0 and dy == 1:
+                return "v"
+            if dx == 0 and dy == -1:
+                return "^"
+            if dx == 1 and dy == 1:
+                return "\\"
+            if dx == -1 and dy == -1:
+                return "\\"
+            if dx == 1 and dy == -1:
+                return "/"
+            if dx == -1 and dy == 1:
+                return "/"
+            if dx != 0:
+                return "-"
+            if dy != 0:
+                return "|"
+            return "+"
+        else:
+            if dx == 1 and dy == 0:
+                return "\u2192"  # right arrow
+            if dx == -1 and dy == 0:
+                return "\u2190"  # left arrow
+            if dx == 0 and dy == 1:
+                return "\u2193"  # down arrow
+            if dx == 0 and dy == -1:
+                return "\u2191"  # up arrow
+            if dx == 1 and dy == 1:
+                return "\u2198"  # down-right
+            if dx == -1 and dy == 1:
+                return "\u2199"  # down-left
+            if dx == 1 and dy == -1:
+                return "\u2197"  # up-right
+            if dx == -1 and dy == -1:
+                return "\u2196"  # up-left
+            return "+"
 
 
 class GroundUnit(Unit):


### PR DESCRIPTION
## Summary
- load DejaVuSansMono.ttf bundled in the repo before searching system fonts
- toggle ASCII fallback when no Unicode-aware font is available
- show ASCII characters for unit orders when necessary
- mention fallback logic in README

## Testing
- `python -m compileall -q command_line_conflict`

------
https://chatgpt.com/codex/tasks/task_e_6861fb9d2a28832186fdbc6910264ea3