### PR TITLE
⚡ Bolt: Optimize `Map.draw` by hoisting invariant rendering operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,7 @@
 ## 2025-05-29 - Spatial Lookups for Selection
 **Learning:** Iterating over all entities to find what was clicked is O(N) and redundant when a spatial hash map exists. `get_entities_at_position` provides O(1) access. Similarly, iterating only components of interest (e.g., `Selectable`) reduces overhead for global operations like drag selection.
 **Action:** Always prefer spatial lookups or component-specific iterators over iterating `game_state.entities.items()` when possible.
+
+## 2025-05-30 - Map Drawing Optimization
+**Learning:** Calling `pygame.font.render` and `pygame.transform.scale` inside the inner rendering loop for static map elements (like walls) causes severe performance degradation, doing O(N) expensive text renders when the result is identical.
+**Action:** Always hoist invariant rendering operations (like text rendering and scaling of identical sprites) out of loops. Render once per frame and blit multiple times.

--- a/command_line_conflict/maps/base.py
+++ b/command_line_conflict/maps/base.py
@@ -155,17 +155,21 @@ class Map:
             font: The pygame font to use for rendering the walls.
             camera: The camera object for view/zoom (optional).
         """
+        grid_size = config.GRID_SIZE
+        if camera:
+            grid_size = int(config.GRID_SIZE * camera.zoom)
+
+        # Pre-render and scale the wall character once per frame instead of per wall
+        ch = font.render("#", True, (100, 100, 100))
+        ch = pygame.transform.scale(ch, (grid_size, grid_size))
+
         for x, y in self.walls:
-            grid_size = config.GRID_SIZE
             if camera:
                 draw_x = (x - camera.x) * config.GRID_SIZE * camera.zoom
                 draw_y = (y - camera.y) * config.GRID_SIZE * camera.zoom
-                grid_size = int(config.GRID_SIZE * camera.zoom)
             else:
-                draw_x = x * grid_size
-                draw_y = y * grid_size
-            ch = font.render("#", True, (100, 100, 100))
-            ch = pygame.transform.scale(ch, (grid_size, grid_size))
+                draw_x = x * config.GRID_SIZE
+                draw_y = y * config.GRID_SIZE
             surf.blit(ch, (draw_x, draw_y))
 
     def to_dict(self) -> dict:

--- a/tests/unit/systems/test_floating_text.py
+++ b/tests/unit/systems/test_floating_text.py
@@ -11,7 +11,6 @@ from command_line_conflict.systems.combat_system import CombatSystem
 from command_line_conflict.systems.ui_system import UISystem
 
 
-
 class TestFloatingText:
     @pytest.fixture
     def mock_camera(self):


### PR DESCRIPTION
💡 **What:** Hoisted the `pygame.font.render` and `pygame.transform.scale` calls out of the inner `for x, y in self.walls:` loop in `Map.draw` in `command_line_conflict/maps/base.py`.

🎯 **Why:** The character (`#`), color, and scaled size are identical for all wall tiles drawn in a single frame. Previously, the code was expensively recreating this surface for every single wall on the map during the draw call, causing an O(N) performance hit for an operation that only needs to happen O(1) times.

📊 **Impact:** Significantly reduces CPU overhead during map drawing by rendering the `#` character exactly once per frame and blitting it $N$ times, rather than rendering it $N$ times.

🔬 **Measurement:** Measured by profiling `Map.draw` during high-density wall scenes. No visual regressions introduced. Added documentation to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [16916578870387082612](https://jules.google.com/task/16916578870387082612) started by @tsainez*