### PR TITLE
🎨 Palette: Use exact text measurement for tooltip widths

### DIFF
--- a/command_line_conflict/systems/ui_system.py
+++ b/command_line_conflict/systems/ui_system.py
@@ -579,7 +579,8 @@ class UISystem:
         # Determine tooltip dimensions
         padding = 5
         line_height = 16
-        width = max(len(line) * 7 for line in lines) + padding * 2  # Approx width
+        max_line_width = max(self.small_font.size(line)[0] for line in lines)
+        width = max_line_width + padding * 2
         height = len(lines) * line_height + padding * 2
 
         x, y = screen_pos

--- a/command_line_conflict/utils/profiler.py
+++ b/command_line_conflict/utils/profiler.py
@@ -26,7 +26,7 @@ class Profiler:
         if self.enabled:
             tracemalloc.start()
 
-        self.metrics_buffer = []
+        self.metrics_buffer: list[list[str | int]] = []
         self.frame_count = 0
         self.total_time = 0.0
         self.fps = 0.0

--- a/command_line_conflict/utils/targeting.py
+++ b/command_line_conflict/utils/targeting.py
@@ -74,9 +74,10 @@ class Targeting:
             for x in range(min_x, max_x + 1):
                 for y in range(min_y, max_y + 1):
                     # Retrieve potential targets from the spatial map
-                    cell_entities = game_state.spatial_map.get((x, y))
-                    if not cell_entities:
+                    cell_entities_opt = game_state.spatial_map.get((x, y))
+                    if not cell_entities_opt:
                         continue
+                    cell_entities = cell_entities_opt
 
                     for other_id in cell_entities:
                         if other_id == my_id:


### PR DESCRIPTION
* 💡 **What:** Modified `draw_tooltip` in `UISystem` to calculate background rectangles using precise Pygame font dimension APIs instead of naive character counts.
* 🎯 **Why:** To prevent text cutoffs or overly wide tooltips, improving overall visual polish and the game interface UX.
* 📸 **Before/After:** No images attached.
* ♿ **Accessibility:** Prevents potential text occlusion and layout inconsistency when variable-width strings are used.

---
*PR created automatically by Jules for task [12045410756052488629](https://jules.google.com/task/12045410756052488629) started by @tsainez*