### PR TITLE
Fix unit AI to match the design: chassis dumb, immortal self-preserves

### DIFF
--- a/command_line_conflict/components/movable.py
+++ b/command_line_conflict/components/movable.py
@@ -23,3 +23,7 @@ class Movable(Component):
 
         # Optimization: Throttling for pathfinding failures
         self.path_retry_timer: float = 0.0
+
+        # For non-intelligent units: ensure we only ping the player once
+        # per stuck event instead of every frame.
+        self.stuck_notified: bool = False

--- a/command_line_conflict/systems/ai_system.py
+++ b/command_line_conflict/systems/ai_system.py
@@ -1,4 +1,5 @@
 from ..components.attack import Attack
+from ..components.flee import Flee
 from ..components.player import Player
 from ..components.position import Position
 from ..components.vision import Vision
@@ -38,6 +39,14 @@ class AISystem:
             # Attack component is guaranteed by the get_entities_with_component call,
             # but we still check it to be safe and get the reference.
             if not attack:
+                continue
+
+            # Self-preservation: a fleeing unit (e.g. immortal at low HP) must
+            # not auto-acquire a target, otherwise the combat system would
+            # override the flee path and chase the enemy.
+            flee = components.get(Flee)
+            if flee and flee.is_fleeing:
+                attack.attack_target = None
                 continue
 
             # Find a target if we don't have one

--- a/command_line_conflict/systems/movement_system.py
+++ b/command_line_conflict/systems/movement_system.py
@@ -1,5 +1,7 @@
 from ..components.movable import Movable
+from ..components.player import Player
 from ..components.position import Position
+from ..components.unit_identity import UnitIdentity
 from ..game_state import GameState
 from ..logger import log
 
@@ -11,7 +13,12 @@ class MovementSystem:
     PATH_RETRY_INTERVAL = 1.0
 
     def set_target(self, game_state: GameState, entity_id: int, x: int, y: int) -> None:
-        """Sets a new movement target for an entity and calculates the path.
+        """Sets a new movement target for an entity.
+
+        Intelligent units (e.g. rover, arachnotron) compute an A* path that
+        avoids walls and other units. Non-intelligent units (e.g. chassis
+        workers) skip pathfinding entirely and walk in a straight line, so
+        the player must micro them around obstacles.
 
         Args:
             game_state: The current state of the game.
@@ -30,19 +37,20 @@ class MovementSystem:
         movable.target_x = x
         movable.target_y = y
         movable.path_retry_timer = 0.0  # Reset retry timer on manual target set
+        movable.stuck_notified = False  # Allow a fresh stuck-ping for the new order
 
-        extra_obstacles = None
-        exclude_obstacles = None
-        if movable.intelligent:
-            extra_obstacles = game_state.spatial_map
-            exclude_obstacles = {(x, y)}
+        if not movable.intelligent:
+            # Non-intelligent units do not pathfind. They walk in a straight
+            # line; the update loop will detect collisions and ping the player.
+            movable.path = []
+            return
 
         movable.path = game_state.map.find_path(
             (int(position.x), int(position.y)),
             (x, y),
             can_fly=movable.can_fly,
-            extra_obstacles=extra_obstacles,
-            exclude_obstacles=exclude_obstacles,
+            extra_obstacles=game_state.spatial_map,
+            exclude_obstacles={(x, y)},
         )
 
         if movable.path:
@@ -124,16 +132,16 @@ class MovementSystem:
             if movable.path:
                 next_x, next_y = movable.path[0]
 
-                # Collision check for non-intelligent units
+                # Collision check for non-intelligent units. With the chassis
+                # design they don't have paths anymore, but keep the guard so
+                # any external system that sets a path (e.g. wander) still
+                # produces a stuck-ping rather than silently clipping.
                 if not movable.intelligent:
                     # Optimized: Use is_position_occupied to avoid list allocation
                     if game_state.is_position_occupied(next_x, next_y, exclude_entity_id=entity_id):
                         log.debug(f"Collision detected for non-intelligent entity {entity_id} at ({next_x}, {next_y})")
+                        self._notify_stuck(game_state, entity_id, blocked_by_wall=False, blocked_by_unit=True)
                         movable.path = []
-                        # movable.target_x = None
-                        # movable.target_y = None
-                        # If non-intelligent collision, maybe we should just stop?
-                        # Reverting to original behavior for non-intelligent:
                         movable.target_x = None
                         movable.target_y = None
                         continue
@@ -167,6 +175,19 @@ class MovementSystem:
                 dy = movable.target_y - position.y
                 dist = (dx * dx + dy * dy) ** 0.5
                 if dist < 0.01:
+                    # The unit has effectively arrived. If the target tile
+                    # itself is blocked we're stuck on the destination, not
+                    # mid-route, so ping the player here too.
+                    tix, tiy = int(movable.target_x), int(movable.target_y)
+                    arrived_blocked_wall = not movable.can_fly and not game_state.map.is_walkable(tix, tiy)
+                    arrived_blocked_unit = (not arrived_blocked_wall) and game_state.is_position_occupied(
+                        tix, tiy, exclude_entity_id=entity_id
+                    )
+                    if arrived_blocked_wall or arrived_blocked_unit:
+                        log.debug(f"Collision detected for non-intelligent entity {entity_id} " f"at target ({tix}, {tiy})")
+                        self._notify_stuck(game_state, entity_id, arrived_blocked_wall, arrived_blocked_unit)
+                    movable.target_x = None
+                    movable.target_y = None
                     continue
 
                 step = min(movable.speed * dt, dist)
@@ -174,12 +195,56 @@ class MovementSystem:
                 proposed_x = position.x + step * dx / dist
                 proposed_y = position.y + step * dy / dist
 
-                # Collision check for non-intelligent units
-                # Optimized: Use is_position_occupied to avoid list allocation
-                if game_state.is_position_occupied(int(proposed_x), int(proposed_y), exclude_entity_id=entity_id):
+                pix, piy = int(proposed_x), int(proposed_y)
+
+                blocked_by_wall = not movable.can_fly and not game_state.map.is_walkable(pix, piy)
+                blocked_by_unit = (not blocked_by_wall) and game_state.is_position_occupied(
+                    pix, piy, exclude_entity_id=entity_id
+                )
+
+                if blocked_by_wall or blocked_by_unit:
                     log.debug(f"Collision detected for non-intelligent entity {entity_id} at ({proposed_x}, {proposed_y})")
+                    self._notify_stuck(game_state, entity_id, blocked_by_wall, blocked_by_unit)
                     movable.target_x = None
                     movable.target_y = None
                     continue
 
                 game_state.update_entity_position(entity_id, proposed_x, proposed_y)
+
+    def _notify_stuck(
+        self,
+        game_state: GameState,
+        entity_id: int,
+        blocked_by_wall: bool,
+        blocked_by_unit: bool,
+    ) -> None:
+        """Pings the player that one of their non-intelligent units is stuck.
+
+        Emits a single log event per stuck order so the chat/log overlay shows
+        a notification. Non-human owners (AI, neutral wildlife) are silenced.
+        """
+        components = game_state.entities.get(entity_id)
+        if not components:
+            return
+
+        movable = components.get(Movable)
+        if movable is None or movable.stuck_notified:
+            return
+
+        player = components.get(Player)
+        if not player or not player.is_human:
+            movable.stuck_notified = True
+            return
+
+        identity = components.get(UnitIdentity)
+        unit_label = identity.name.capitalize() if identity else f"Unit {entity_id}"
+
+        if blocked_by_wall and blocked_by_unit:
+            text = f"{unit_label} is stuck!"
+        elif blocked_by_wall:
+            text = f"{unit_label} is blocked by terrain!"
+        else:
+            text = f"{unit_label} is blocked by another unit!"
+
+        game_state.add_event({"type": "log", "text": text, "color": (255, 200, 50)})
+        movable.stuck_notified = True

--- a/tests/unit/systems/test_chassis_stuck_ping.py
+++ b/tests/unit/systems/test_chassis_stuck_ping.py
@@ -1,0 +1,125 @@
+# pylint: disable=redefined-outer-name
+"""Tests for the basic worker (chassis) stuck-ping micro behavior.
+
+The chassis is non-intelligent by design: it does NOT use pathfinding and
+should walk in a straight line. When it bumps into an obstacle (a wall or
+another unit), the movement system pings the player via a chat-log event.
+"""
+
+import pytest
+
+from command_line_conflict.components.movable import Movable
+from command_line_conflict.components.position import Position
+from command_line_conflict.factories import create_chassis, create_rover
+from command_line_conflict.game_state import GameState
+from command_line_conflict.maps.simple_map import SimpleMap
+from command_line_conflict.systems.movement_system import MovementSystem
+
+
+@pytest.fixture
+def game_state():
+    return GameState(SimpleMap())
+
+
+@pytest.fixture
+def movement_system():
+    return MovementSystem()
+
+
+def _drain_log_events(game_state: GameState):
+    return [e for e in game_state.event_queue if e.get("type") == "log"]
+
+
+def test_chassis_does_not_pathfind_around_wall(game_state, movement_system):
+    """A chassis must not produce an A* path; it should walk straight."""
+    unit_id = create_chassis(game_state, x=2, y=5, player_id=1, is_human=True)
+
+    # Place a wall directly between the chassis and its destination.
+    game_state.map.add_wall(5, 5)
+
+    movement_system.set_target(game_state, unit_id, 9, 5)
+
+    movable = game_state.get_component(unit_id, Movable)
+    assert movable.path == [], "Chassis must not pathfind"
+    assert movable.target_x == 9 and movable.target_y == 5
+
+
+def test_rover_still_pathfinds(game_state, movement_system):
+    """A rover (intelligent) keeps pathfinding for comparison."""
+    unit_id = create_rover(game_state, x=2, y=5, player_id=1, is_human=True)
+    game_state.map.add_wall(5, 5)
+
+    movement_system.set_target(game_state, unit_id, 9, 5)
+
+    movable = game_state.get_component(unit_id, Movable)
+    assert movable.path, "Rover must produce an A* path around the wall"
+    assert (5, 5) not in movable.path
+
+
+def test_chassis_pings_player_when_blocked_by_wall(game_state, movement_system):
+    """When the chassis runs into a wall it must emit a stuck log event."""
+    unit_id = create_chassis(game_state, x=2, y=5, player_id=1, is_human=True)
+    game_state.map.add_wall(5, 5)
+
+    movement_system.set_target(game_state, unit_id, 9, 5)
+
+    # Walk forward until the chassis hits the wall (chassis speed 2, dt 0.1).
+    for _ in range(40):
+        movement_system.update(game_state, dt=0.1)
+
+    log_events = _drain_log_events(game_state)
+    assert log_events, "Expected a stuck-ping log event for the chassis"
+    assert any("terrain" in e["text"].lower() or "stuck" in e["text"].lower() for e in log_events)
+
+    # The order is cleared so the unit doesn't keep grinding into the wall.
+    movable = game_state.get_component(unit_id, Movable)
+    assert movable.target_x is None and movable.target_y is None
+
+    # Position should not have entered the wall tile.
+    pos = game_state.get_component(unit_id, Position)
+    assert int(pos.x) < 5
+
+
+def test_chassis_pings_player_when_blocked_by_unit(game_state, movement_system):
+    """When another unit blocks the path, ping the player exactly once."""
+    unit_id = create_chassis(game_state, x=10, y=10, player_id=1, is_human=True)
+    create_chassis(game_state, x=10, y=12, player_id=2, is_human=False)
+
+    movement_system.set_target(game_state, unit_id, 10, 12)
+
+    for _ in range(40):
+        movement_system.update(game_state, dt=0.1)
+
+    log_events = _drain_log_events(game_state)
+    assert len(log_events) == 1, "Expected exactly one stuck ping per order"
+    assert "another unit" in log_events[0]["text"].lower() or "stuck" in log_events[0]["text"].lower()
+
+
+def test_chassis_does_not_ping_for_ai_owned_units(game_state, movement_system):
+    """Only the human player gets pinged about their own stuck units."""
+    unit_id = create_chassis(game_state, x=10, y=10, player_id=2, is_human=False)
+    create_chassis(game_state, x=10, y=12, player_id=2, is_human=False)
+
+    movement_system.set_target(game_state, unit_id, 10, 12)
+    for _ in range(40):
+        movement_system.update(game_state, dt=0.1)
+
+    assert _drain_log_events(game_state) == []
+
+
+def test_new_order_resets_stuck_notification(game_state, movement_system):
+    """A fresh move command clears the rate-limit so the player can be
+    pinged again for the next order if it also fails."""
+    unit_id = create_chassis(game_state, x=10, y=10, player_id=1, is_human=True)
+    create_chassis(game_state, x=10, y=12, player_id=2, is_human=False)
+
+    movement_system.set_target(game_state, unit_id, 10, 12)
+    for _ in range(40):
+        movement_system.update(game_state, dt=0.1)
+    assert len(_drain_log_events(game_state)) == 1
+
+    # Issue another impossible order; should be pinged again.
+    movement_system.set_target(game_state, unit_id, 10, 12)
+    for _ in range(40):
+        movement_system.update(game_state, dt=0.1)
+    assert len(_drain_log_events(game_state)) == 2

--- a/tests/unit/systems/test_immortal_flee.py
+++ b/tests/unit/systems/test_immortal_flee.py
@@ -1,0 +1,126 @@
+# pylint: disable=redefined-outer-name
+"""Tests for the immortal's self-preservation micro.
+
+The immortal flees once HP drops below 20% while an enemy is in sight. The
+self-preservation micro must:
+  - Drop the attack target so combat doesn't keep firing.
+  - Keep the AI from re-acquiring a target while fleeing.
+  - Move the unit away from the enemy via the movement system.
+"""
+
+import pytest
+
+from command_line_conflict.components.attack import Attack
+from command_line_conflict.components.flee import Flee
+from command_line_conflict.components.health import Health
+from command_line_conflict.components.movable import Movable
+from command_line_conflict.components.position import Position
+from command_line_conflict.factories import create_immortal, create_rover
+from command_line_conflict.game_state import GameState
+from command_line_conflict.maps.simple_map import SimpleMap
+from command_line_conflict.systems.ai_system import AISystem
+from command_line_conflict.systems.combat_system import CombatSystem
+from command_line_conflict.systems.flee_system import FleeSystem
+from command_line_conflict.systems.movement_system import MovementSystem
+
+
+@pytest.fixture
+def game_state():
+    return GameState(SimpleMap())
+
+
+def _systems():
+    return (FleeSystem(), AISystem(), CombatSystem(), MovementSystem())
+
+
+def test_immortal_does_not_flee_at_full_health(game_state):
+    immortal_id = create_immortal(game_state, x=10, y=10, player_id=1, is_human=True)
+    create_rover(game_state, x=12, y=10, player_id=2, is_human=False)
+
+    flee_sys, ai, combat, movement = _systems()
+    flee_sys.update(game_state, 0.1)
+    ai.update(game_state)
+    combat.update(game_state, 0.1)
+    movement.update(game_state, 0.1)
+
+    flee = game_state.get_component(immortal_id, Flee)
+    assert flee.is_fleeing is False
+
+
+def test_immortal_starts_fleeing_below_threshold(game_state):
+    immortal_id = create_immortal(game_state, x=10, y=10, player_id=1, is_human=True)
+    create_rover(game_state, x=12, y=10, player_id=2, is_human=False)
+
+    # Drop the immortal under the 20% flee threshold.
+    health = game_state.get_component(immortal_id, Health)
+    health.hp = int(health.max_hp * 0.1)
+
+    flee_sys, *_ = _systems()
+    flee_sys.update(game_state, 0.1)
+
+    flee = game_state.get_component(immortal_id, Flee)
+    assert flee.is_fleeing is True
+
+
+def test_immortal_drops_attack_target_when_fleeing(game_state):
+    immortal_id = create_immortal(game_state, x=10, y=10, player_id=1, is_human=True)
+    enemy_id = create_rover(game_state, x=12, y=10, player_id=2, is_human=False)
+
+    attack = game_state.get_component(immortal_id, Attack)
+    attack.attack_target = enemy_id
+
+    health = game_state.get_component(immortal_id, Health)
+    health.hp = int(health.max_hp * 0.1)
+
+    flee_sys, ai, *_ = _systems()
+    flee_sys.update(game_state, 0.1)
+    ai.update(game_state)  # Must NOT re-acquire while fleeing
+
+    assert attack.attack_target is None
+
+
+def test_combat_does_not_chase_while_fleeing(game_state):
+    """The bug under test: AI re-targets, then combat overrides flee target."""
+    immortal_id = create_immortal(game_state, x=10, y=10, player_id=1, is_human=True)
+    create_rover(game_state, x=12, y=10, player_id=2, is_human=False)
+
+    health = game_state.get_component(immortal_id, Health)
+    health.hp = int(health.max_hp * 0.1)
+
+    flee_sys, ai, combat, movement = _systems()
+    # One full pseudo-frame in scene order.
+    flee_sys.update(game_state, 0.1)
+    ai.update(game_state)
+    combat.update(game_state, 0.1)
+    movement.update(game_state, 0.1)
+
+    movable = game_state.get_component(immortal_id, Movable)
+    pos = game_state.get_component(immortal_id, Position)
+
+    # Flee target should point AWAY from the enemy (negative x direction).
+    assert movable.target_x is not None
+    assert movable.target_x < 10, f"Expected to flee away (x < 10), got {movable.target_x}"
+
+    # And the immortal should have started moving away.
+    assert pos.x <= 10
+
+
+def test_immortal_stops_fleeing_after_recovery(game_state):
+    """Once HP is back up and no enemy in sight, fleeing ends."""
+    immortal_id = create_immortal(game_state, x=10, y=10, player_id=1, is_human=True)
+    enemy_id = create_rover(game_state, x=12, y=10, player_id=2, is_human=False)
+
+    health = game_state.get_component(immortal_id, Health)
+    health.hp = int(health.max_hp * 0.1)
+
+    flee_sys, *_ = _systems()
+    flee_sys.update(game_state, 0.1)
+    flee = game_state.get_component(immortal_id, Flee)
+    assert flee.is_fleeing is True
+
+    # Recover and remove the enemy.
+    health.hp = health.max_hp
+    game_state.remove_entity(enemy_id)
+
+    flee_sys.update(game_state, 0.1)
+    assert flee.is_fleeing is False

--- a/tests/unit/systems/test_movement_system_logging.py
+++ b/tests/unit/systems/test_movement_system_logging.py
@@ -15,8 +15,9 @@ class TestMovementSystemLogging(unittest.TestCase):
 
     @patch("command_line_conflict.systems.movement_system.log")
     def test_set_target_logs_debug(self, mock_log):
-        # Create a unit
-        unit_id = create_chassis(self.game_state, x=10, y=10, player_id=1)
+        # Use a rover (intelligent) since "Path found" is only logged for
+        # units that actually run pathfinding. The chassis is non-intelligent.
+        unit_id = create_rover(self.game_state, x=10, y=10, player_id=1)
 
         # Move to a valid location
         self.movement_system.set_target(self.game_state, unit_id, 12, 12)
@@ -29,8 +30,9 @@ class TestMovementSystemLogging(unittest.TestCase):
 
     @patch("command_line_conflict.systems.movement_system.log")
     def test_set_target_logs_warning_when_no_path(self, mock_log):
-        # Create a unit
-        unit_id = create_chassis(self.game_state, x=10, y=10, player_id=1)
+        # Pathfinding is only used by intelligent units. The chassis (worker)
+        # is non-intelligent by design and never pathfinds, so use a rover.
+        unit_id = create_rover(self.game_state, x=10, y=10, player_id=1)
 
         # Enclose the unit with walls so no path can be found
         self.game_state.map.add_wall(9, 10)
@@ -54,8 +56,10 @@ class TestMovementSystemLogging(unittest.TestCase):
         # Set target to the obstacle
         self.movement_system.set_target(self.game_state, unit1_id, 10, 11)
 
-        # Run update
-        self.movement_system.update(self.game_state, dt=0.1)
+        # Chassis walks in a straight line; run enough updates for it to
+        # actually reach the blocking unit's tile.
+        for _ in range(10):
+            self.movement_system.update(self.game_state, dt=0.1)
 
         # Check if any debug call contains "Collision detected"
         collision_logged = any("Collision detected" in str(call) for call in mock_log.debug.mock_calls)


### PR DESCRIPTION
Chassis (basic worker) was incorrectly running A* pathfinding. The design
calls for the worker to be dumb -- it should walk in a straight line and
ping the player when stuck. MovementSystem.set_target now skips pathfinding
for non-intelligent units, and the straight-line update branch detects
collisions with walls and units, emitting a one-shot log event so the
chat overlay notifies the human player.

The immortal's self-preservation micro had a system-ordering bug: FleeSystem
cleared the attack target, but AISystem ran next and immediately re-acquired
the closest enemy, then CombatSystem chased it -- overriding the flee target.
AISystem now skips entities that are currently fleeing, so the immortal
actually retreats once HP drops below 20%.

Factory chassis -> rover (and rover -> arachnotron) already produced
pathfinding-capable output via Movable(intelligent=True), so no change there.