### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unauthorized Access to Cheats in Production

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -25,3 +25,7 @@
 **Vulnerability:** Allowing the application to write to its own source directory (`maps_dir`) creates a risk of code overwrite or integrity violation, even with extension checks.
 **Learning:** Enforcing a strict "write only to user data" policy requires updating all default paths in the UI (e.g., Editor) to prevent usability regressions. Security restrictions often necessitate UX changes.
 **Prevention:** Removed `maps_dir` from `allowed_dirs` in `Map.save_to_file` and updated `EditorScene` to default to `user_data_dir`.
+## 2026-05-10 - [Cheat Mode Bypass]
+**Vulnerability:** The developer cheats (F1 for reveal map, F2 for god mode) in GameScene were not gated by the DEBUG configuration flag.
+**Learning:** Even if a feature is intended only for development, it must be explicitly protected by a configuration check. Otherwise, it might be accessible in production builds.
+**Prevention:** Wrap all debug and cheat functionalities in a check against the relevant configuration flag (e.g., `if config.DEBUG:`).

--- a/command_line_conflict/scenes/game.py
+++ b/command_line_conflict/scenes/game.py
@@ -321,17 +321,19 @@ class GameScene:
                             )
 
                     # Debug cheats
-                    if event.key == pygame.K_F1:
-                        self.cheats["reveal_map"] = not self.cheats["reveal_map"]
-                        status = "Enabled" if self.cheats["reveal_map"] else "Disabled"
-                        log.info(f"Cheat 'Reveal Map' toggled: {self.cheats['reveal_map']}")
-                        self.chat_system.add_message(f"Cheat: Map Reveal {status}", (255, 0, 255))
-                    elif event.key == pygame.K_F2:
-                        self.cheats["god_mode"] = not self.cheats["god_mode"]
-                        status = "Enabled" if self.cheats["god_mode"] else "Disabled"
-                        log.info(f"Cheat 'God Mode' toggled: {self.cheats['god_mode']}")
-                        self.chat_system.add_message(f"Cheat: God Mode {status}", (255, 0, 255))
-                    elif event.key == pygame.K_TAB:
+                    if config.DEBUG:
+                        if event.key == pygame.K_F1:
+                            self.cheats["reveal_map"] = not self.cheats["reveal_map"]
+                            status = "Enabled" if self.cheats["reveal_map"] else "Disabled"
+                            log.info(f"Cheat 'Reveal Map' toggled: {self.cheats['reveal_map']}")
+                            self.chat_system.add_message(f"Cheat: Map Reveal {status}", (255, 0, 255))
+                        elif event.key == pygame.K_F2:
+                            self.cheats["god_mode"] = not self.cheats["god_mode"]
+                            status = "Enabled" if self.cheats["god_mode"] else "Disabled"
+                            log.info(f"Cheat 'God Mode' toggled: {self.cheats['god_mode']}")
+                            self.chat_system.add_message(f"Cheat: God Mode {status}", (255, 0, 255))
+
+                    if event.key == pygame.K_TAB:
                         # Switch sides
                         self.selection_system.clear_selection(self.game_state)
                         if self.current_player_id == 1:


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Developer cheats (God mode, Map reveal) were accessible in production builds because they were not gated by the `DEBUG` flag in `GameScene`.
🎯 Impact: Players could use keyboard shortcuts to reveal the entire map or enable god mode, ruining the intended game experience and bypassing game logic.
🔧 Fix: Wrapped the F1 and F2 debug key checks in `command_line_conflict/scenes/game.py` with `if config.DEBUG:`. Added a journal entry for the learning.
✅ Verification: Ran `pytest tests/security/test_cheats_protection.py`, which passed. Tests verify that cheats cannot be toggled when `DEBUG` is false.

---
*PR created automatically by Jules for task [11395984040983214643](https://jules.google.com/task/11395984040983214643) started by @tsainez*