### PR TITLE
🎨 Palette: Add mouse click support to end screens

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-10 - Found Cursor Issues
+**Learning:** Defeat and Victory scenes do not show mouse cursor or support mouse click. Adding simple mouse cursor state improvements to Defeat and Victory scenes would make them more accessible and user-friendly.
+**Action:** Add cursor state handling to Defeat/Victory scenes, or just improve overall cursor UX.

--- a/command_line_conflict/scenes/defeat.py
+++ b/command_line_conflict/scenes/defeat.py
@@ -12,6 +12,7 @@ class DefeatScene:
         """
         self.game = game
         self.font = game.font
+        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
 
     def handle_event(self, event):
         """Handles events for the defeat scene.
@@ -22,6 +23,8 @@ class DefeatScene:
         if event.type == pygame.KEYDOWN:
             if event.key == pygame.K_RETURN:
                 self.game.scene_manager.switch_to("menu")
+        elif event.type == pygame.MOUSEBUTTONDOWN:
+            self.game.scene_manager.switch_to("menu")
 
     def update(self, dt):
         """Updates the defeat scene.
@@ -42,7 +45,7 @@ class DefeatScene:
         screen.blit(text, text_rect)
 
         # Instructions to go back to menu
-        instruction_text = self.font.render("Press Enter to return to the menu", True, (255, 255, 255))
+        instruction_text = self.font.render("Press Enter or Click to return to the menu", True, (255, 255, 255))
         instruction_rect = instruction_text.get_rect(
             center=(
                 self.game.screen.get_width() / 2,

--- a/command_line_conflict/scenes/victory.py
+++ b/command_line_conflict/scenes/victory.py
@@ -12,6 +12,7 @@ class VictoryScene:
         """
         self.game = game
         self.font = game.font
+        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
 
     def handle_event(self, event):
         """Handles events for the victory scene.
@@ -22,6 +23,8 @@ class VictoryScene:
         if event.type == pygame.KEYDOWN:
             if event.key == pygame.K_RETURN:
                 self.game.scene_manager.switch_to("menu")
+        elif event.type == pygame.MOUSEBUTTONDOWN:
+            self.game.scene_manager.switch_to("menu")
 
     def update(self, dt):
         """Updates the victory scene.
@@ -42,7 +45,7 @@ class VictoryScene:
         screen.blit(text, text_rect)
 
         # Instructions to go back to menu
-        instruction_text = self.font.render("Press Enter to return to the menu", True, (255, 255, 255))
+        instruction_text = self.font.render("Press Enter or Click to return to the menu", True, (255, 255, 255))
         instruction_rect = instruction_text.get_rect(
             center=(
                 self.game.screen.get_width() / 2,


### PR DESCRIPTION
**What:** Added mouse click support (`pygame.MOUSEBUTTONDOWN`) to the `DefeatScene` and `VictoryScene` to allow players to return to the main menu without needing the keyboard. Also updated the on-screen instruction text to explicitly say "Press Enter or Click to return to the menu" and reset the cursor to `SYSTEM_CURSOR_ARROW`.

**Why:** To improve accessibility and user experience by providing an alternative to the keyboard for continuing past the end screens. The cursor reset ensures that context-specific cursors (like crosshairs from gameplay) don't bleed over into non-gameplay scenes.

---
*PR created automatically by Jules for task [5051020830144531038](https://jules.google.com/task/5051020830144531038) started by @tsainez*