### PR TITLE
🎨 Palette: Improve end-screen interactivity cues

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Pygame Custom Text Inputs Lack Focus Indicators
 **Learning:** Custom-built text inputs in Pygame UI systems inherently lack native focus indicators (like blinking cursors). This makes it difficult for users to know if an input field is active and ready for typing, severely impacting keyboard navigation usability.
 **Action:** Always manually implement a blinking cursor (e.g., toggled via `pygame.time.get_ticks() % 1000 < 500`) at the end of the text surface in any custom Pygame text input to provide immediate, visible feedback of input focus.
+## 2026-05-10 - Scene-wide Interactivity Cues
+**Learning:** Pygame scenes without explicit button components (like full-screen click-to-continue prompts in Defeat/Victory scenes) leave users guessing if the screen is interactive or frozen.
+**Action:** When an entire screen acts as a button, provide visual cues: change the cursor to `pygame.SYSTEM_CURSOR_HAND` and add subtle animations (like pulsing text color via `math.sin(time)`) to the call-to-action to indicate interactivity.

--- a/command_line_conflict/scenes/defeat.py
+++ b/command_line_conflict/scenes/defeat.py
@@ -1,3 +1,5 @@
+import math
+
 import pygame
 
 
@@ -12,7 +14,8 @@ class DefeatScene:
         """
         self.game = game
         self.font = game.font
-        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
+        self.time = 0.0
+        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
 
     def handle_event(self, event):
         """Handles events for the defeat scene.
@@ -32,6 +35,7 @@ class DefeatScene:
         Args:
             dt: The time since the last frame.
         """
+        self.time += dt
 
     def draw(self, screen):
         """Draws the defeat scene.
@@ -45,7 +49,10 @@ class DefeatScene:
         screen.blit(text, text_rect)
 
         # Instructions to go back to menu
-        instruction_text = self.font.render("Press Enter or Click to return to the menu", True, (255, 255, 255))
+        pulse = (math.sin(self.time * 5) + 1) / 2
+        color_val = 150 + int(105 * pulse)
+        pulse_color = (color_val, color_val, color_val)
+        instruction_text = self.font.render("Press Enter or Click to return to the menu", True, pulse_color)
         instruction_rect = instruction_text.get_rect(
             center=(
                 self.game.screen.get_width() / 2,

--- a/command_line_conflict/scenes/victory.py
+++ b/command_line_conflict/scenes/victory.py
@@ -1,3 +1,5 @@
+import math
+
 import pygame
 
 
@@ -12,7 +14,8 @@ class VictoryScene:
         """
         self.game = game
         self.font = game.font
-        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
+        self.time = 0.0
+        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
 
     def handle_event(self, event):
         """Handles events for the victory scene.
@@ -32,6 +35,7 @@ class VictoryScene:
         Args:
             dt: The time since the last frame.
         """
+        self.time += dt
 
     def draw(self, screen):
         """Draws the victory scene.
@@ -45,7 +49,10 @@ class VictoryScene:
         screen.blit(text, text_rect)
 
         # Instructions to go back to menu
-        instruction_text = self.font.render("Press Enter or Click to return to the menu", True, (255, 255, 255))
+        pulse = (math.sin(self.time * 5) + 1) / 2
+        color_val = 150 + int(105 * pulse)
+        pulse_color = (color_val, color_val, color_val)
+        instruction_text = self.font.render("Press Enter or Click to return to the menu", True, pulse_color)
         instruction_rect = instruction_text.get_rect(
             center=(
                 self.game.screen.get_width() / 2,


### PR DESCRIPTION
* **💡 What:** Added a `pygame.SYSTEM_CURSOR_HAND` pointer and a subtle pulsing animation to the "Press Enter or Click to return to the menu" instruction text on both the Victory and Defeat screens.
* **🎯 Why:** Previously, these screens used the default arrow cursor and static text, which didn't effectively communicate that the screen was interactive (i.e., that clicking anywhere would return the user to the menu). This small touch improves the intuitive feel of the UI by clearly signaling the actionable state.
* **♿ Accessibility:** Improves visual feedback and affordance for interactive elements.

---
*PR created automatically by Jules for task [399611005838063828](https://jules.google.com/task/399611005838063828) started by @tsainez*