### PR TITLE
🎨 Palette: Add pulsing text and hand cursor to Victory/Defeat scenes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Pygame Custom Text Inputs Lack Focus Indicators
 **Learning:** Custom-built text inputs in Pygame UI systems inherently lack native focus indicators (like blinking cursors). This makes it difficult for users to know if an input field is active and ready for typing, severely impacting keyboard navigation usability.
 **Action:** Always manually implement a blinking cursor (e.g., toggled via `pygame.time.get_ticks() % 1000 < 500`) at the end of the text surface in any custom Pygame text input to provide immediate, visible feedback of input focus.
+## 2024-05-18 - Full-Screen Pygame Scenes Need Interaction Cues
+**Learning:** Pygame scenes like Victory or Defeat screens that are essentially full-screen click-to-continue prompts lack native affordances. Users may not realize the text is actionable or the screen is waiting for input.
+**Action:** In Pygame scenes without explicit button components (like full-screen click-to-continue prompts), use subtle visual cues such as pulsing text (via `math.sin(time)`) and changing the cursor to `pygame.SYSTEM_CURSOR_HAND` to clearly indicate interactivity.

--- a/command_line_conflict/scenes/defeat.py
+++ b/command_line_conflict/scenes/defeat.py
@@ -1,3 +1,5 @@
+import math
+
 import pygame
 
 
@@ -12,7 +14,8 @@ class DefeatScene:
         """
         self.game = game
         self.font = game.font
-        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
+        self.time = 0.0
+        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
 
     def handle_event(self, event):
         """Handles events for the defeat scene.
@@ -32,6 +35,7 @@ class DefeatScene:
         Args:
             dt: The time since the last frame.
         """
+        self.time += dt
 
     def draw(self, screen):
         """Draws the defeat scene.
@@ -44,8 +48,13 @@ class DefeatScene:
         text_rect = text.get_rect(center=(self.game.screen.get_width() / 2, self.game.screen.get_height() / 2))
         screen.blit(text, text_rect)
 
+        # Pulse effect
+        pulse = (math.sin(self.time * 5) + 1) / 2
+        color_val = 150 + int(105 * pulse)
+        pulse_color = (color_val, color_val, color_val)
+
         # Instructions to go back to menu
-        instruction_text = self.font.render("Press Enter or Click to return to the menu", True, (255, 255, 255))
+        instruction_text = self.font.render("Press Enter or Click to return to the menu", True, pulse_color)
         instruction_rect = instruction_text.get_rect(
             center=(
                 self.game.screen.get_width() / 2,

--- a/command_line_conflict/scenes/victory.py
+++ b/command_line_conflict/scenes/victory.py
@@ -1,3 +1,5 @@
+import math
+
 import pygame
 
 
@@ -12,7 +14,8 @@ class VictoryScene:
         """
         self.game = game
         self.font = game.font
-        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
+        self.time = 0.0
+        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
 
     def handle_event(self, event):
         """Handles events for the victory scene.
@@ -32,6 +35,7 @@ class VictoryScene:
         Args:
             dt: The time since the last frame.
         """
+        self.time += dt
 
     def draw(self, screen):
         """Draws the victory scene.
@@ -44,8 +48,13 @@ class VictoryScene:
         text_rect = text.get_rect(center=(self.game.screen.get_width() / 2, self.game.screen.get_height() / 2))
         screen.blit(text, text_rect)
 
+        # Pulse effect
+        pulse = (math.sin(self.time * 5) + 1) / 2
+        color_val = 150 + int(105 * pulse)
+        pulse_color = (color_val, color_val, color_val)
+
         # Instructions to go back to menu
-        instruction_text = self.font.render("Press Enter or Click to return to the menu", True, (255, 255, 255))
+        instruction_text = self.font.render("Press Enter or Click to return to the menu", True, pulse_color)
         instruction_rect = instruction_text.get_rect(
             center=(
                 self.game.screen.get_width() / 2,


### PR DESCRIPTION
This PR introduces subtle visual cues (pulsing text and pointer hand cursor) to the end-game Defeat and Victory scenes. Since these are full-screen interactive prompts, these affordances better communicate to the user that they need to click or press enter to continue. 

Fixes #UX-Accessibility

---
*PR created automatically by Jules for task [4755462170145408260](https://jules.google.com/task/4755462170145408260) started by @tsainez*