### PR TITLE
🎨 Palette: Fix persistent cursor states on scene switch

### DIFF
--- a/command_line_conflict/engine.py
+++ b/command_line_conflict/engine.py
@@ -45,6 +45,7 @@ class SceneManager:
             scene_name: The name of the scene to switch to.
         """
         log.debug(f"Switching scene to: {scene_name}")
+        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
         if scene_name == "game":
             self.scenes["game"] = GameScene(self.game)
         elif scene_name == "editor":

--- a/command_line_conflict/scenes/menu.py
+++ b/command_line_conflict/scenes/menu.py
@@ -94,9 +94,6 @@ class MenuScene:
     def _trigger_option(self, option_index):
         option_text = self.menu_options[option_index]
 
-        # Reset cursor before switching scenes
-        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
-
         if option_text == "Continue Campaign":
             self.game.scene_manager.switch_to("game")
         elif option_text == "New Game":

--- a/command_line_conflict/scenes/settings.py
+++ b/command_line_conflict/scenes/settings.py
@@ -131,7 +131,6 @@ class SettingsScene:
             config.DEBUG = not config.DEBUG
             log.info(f"Debug mode set to {config.DEBUG}")
         elif option_name == "Back":
-            pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
             self.game.scene_manager.switch_to("menu")
 
     def update(self, dt):


### PR DESCRIPTION
* 💡 What: Reset the mouse cursor to `SYSTEM_CURSOR_ARROW` centrally inside `SceneManager.switch_to`.
* 🎯 Why: Fixes a UX glitch where cursors (like hands or crosshairs) would remain stuck when transitioning back to non-interactive screens, providing a consistent interaction baseline.
* 📸 Before/After: Visual cursor issue, no screenshot attached.
* ♿ Accessibility: Improves visual feedback predictability for users relying on mouse cues.

---
*PR created automatically by Jules for task [872458755967632729](https://jules.google.com/task/872458755967632729) started by @tsainez*