### PR TITLE
🎨 Palette: Update pause message to include Space key instruction

### DIFF
--- a/command_line_conflict/systems/ui_system.py
+++ b/command_line_conflict/systems/ui_system.py
@@ -527,7 +527,7 @@ class UISystem:
         self.screen.blit(text, text_rect)
 
         # Draw instruction text - use cached method with medium font
-        instruction = self._get_text_surface("Press P to Resume", (200, 200, 200), "medium")
+        instruction = self._get_text_surface("Press P or Space to Resume", (200, 200, 200), "medium")
         instruction_rect = instruction.get_rect(center=(config.SCREEN_WIDTH / 2, config.SCREEN_HEIGHT / 2 + 50))
         self.screen.blit(instruction, instruction_rect)
 


### PR DESCRIPTION
* 💡 What: Updated the pause overlay instruction text to indicate that both 'P' and 'Space' can be used to resume the game.
* 🎯 Why: Spacebar is a common and intuitive hotkey for pausing/resuming. The game logic already supported it, and the key bindings menu mentioned it, but the explicit pause screen prompt only mentioned 'P', creating potential confusion.
* ♿ Accessibility: Improves intuitive keyboard usage by clearly stating all available primary controls for a critical action.

---
*PR created automatically by Jules for task [6080347076811039812](https://jules.google.com/task/6080347076811039812) started by @tsainez*