### PR TITLE
🎨 Palette: Add Escape Key Navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2026-05-10 - Scene-wide Interactivity Cues
 **Learning:** Pygame scenes without explicit button components (like full-screen click-to-continue prompts in Defeat/Victory scenes) leave users guessing if the screen is interactive or frozen.
 **Action:** When an entire screen acts as a button, provide visual cues: change the cursor to `pygame.SYSTEM_CURSOR_HAND` and add subtle animations (like pulsing text color via `math.sin(time)`) to the call-to-action to indicate interactivity.
+## 2026-05-17 - Missing Escape Key Navigation
+**Learning:** Some scenes (Settings, Menu) were missing `pygame.K_ESCAPE` handling, which is a common and expected UX pattern for navigating backwards or quitting in games. This breaks standard keyboard navigation flows.
+**Action:** Always map the Escape key to the logical "Back" or "Quit" action in all full-screen menu scenes to provide a consistent and intuitive keyboard navigation experience.

--- a/command_line_conflict/scenes/menu.py
+++ b/command_line_conflict/scenes/menu.py
@@ -86,6 +86,8 @@ class MenuScene:
                 self.selected_option = (self.selected_option + 1) % len(self.menu_options)
             elif event.key == pygame.K_RETURN:
                 self._trigger_option(self.selected_option)
+            elif event.key == pygame.K_ESCAPE:
+                self._trigger_option(self.menu_options.index("Quit"))
 
             if self.selected_option != old_selection:
                 self.sound_system.play_sound("click_select")

--- a/command_line_conflict/scenes/settings.py
+++ b/command_line_conflict/scenes/settings.py
@@ -112,6 +112,8 @@ class SettingsScene:
                 self._change_volume(option_name, direction)
             elif event.key == pygame.K_RETURN:
                 self._trigger_option(option_name)
+            elif event.key == pygame.K_ESCAPE:
+                self._trigger_option("Back")
 
             if self.selected_option != old_selection:
                 self.sound_system.play_sound("click_select")

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,0 @@
-1. **Analyze UX in `SettingsScene`**: The Settings menu lacks audio feedback on hover and keyboard navigation, unlike the `MenuScene`. This causes a lack of immediate tactile confirmation for the user, lowering the perceived responsiveness and accessibility of the UI.
-2. **Implement audio feedback**: Instantiate a local `SoundSystem` in `SettingsScene` and trigger `click_select` on mouse hover changes and keyboard up/down presses.
-3. **Enhance volume adjustment feedback**: When users adjust Master or SFX volume, update the volume of the `SoundSystem` on the fly and play a sound so they can instantly hear the result of their change.
-4. **Update `.Jules/palette.md`**: Log this critical learning about UI consistency and audio feedback in Pygame non-ECS scenes.
-5. **Pre-commit and Test**: Verify the implementation with tests and linting.
-6. **Submit**: Create PR.

--- a/tests/unit/scenes/test_menu_scene.py
+++ b/tests/unit/scenes/test_menu_scene.py
@@ -42,6 +42,19 @@ class TestMenuScene(unittest.TestCase):
 
         self.mock_game.scene_manager.switch_to.assert_called_with("editor")
 
+    def test_escape_key_triggers_quit(self):
+        # Ensure we are not already trying to quit
+        self.scene.quit_confirm = False
+
+        event = MagicMock()
+        event.type = pygame.KEYDOWN
+        event.key = pygame.K_ESCAPE
+
+        self.scene.handle_event(event)
+
+        # The first time Quit is selected, quit_confirm should be True
+        self.assertTrue(self.scene.quit_confirm)
+
     def test_mouse_hover_selects_option(self):
         # Setup mock rects
         mock_rect_0 = MagicMock()

--- a/tests/unit/scenes/test_settings_scene.py
+++ b/tests/unit/scenes/test_settings_scene.py
@@ -138,3 +138,12 @@ def test_mouse_click_trigger(settings_scene):
 
     settings_scene.handle_event(event)
     settings_scene.game.scene_manager.switch_to.assert_called_with("menu")
+
+
+def test_escape_key_navigates_back(settings_scene):
+    event = MagicMock()
+    event.type = pygame.KEYDOWN
+    event.key = pygame.K_ESCAPE
+
+    settings_scene.handle_event(event)
+    settings_scene.game.scene_manager.switch_to.assert_called_with("menu")


### PR DESCRIPTION
🎨 Palette: Add Escape Key Navigation

💡 What: Added `pygame.K_ESCAPE` handling to `SettingsScene` to act as "Back" and to `MenuScene` to act as "Quit". Added corresponding tests for these new behaviors.
🎯 Why: Pressing Escape is a highly expected UX pattern for navigating backwards or quitting in games. This improves overall keyboard accessibility and navigation consistency.
♿ Accessibility: Improved keyboard navigation support for main menus.

---
*PR created automatically by Jules for task [7855177566594691284](https://jules.google.com/task/7855177566594691284) started by @tsainez*