### PR TITLE
🎨 Palette: Add Escape key support and fix custom mouse cursor in Victory/Defeat scenes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -10,3 +10,4 @@
 ## 2026-05-17 - Missing Escape Key Navigation
 **Learning:** Some scenes (Settings, Menu) were missing `pygame.K_ESCAPE` handling, which is a common and expected UX pattern for navigating backwards or quitting in games. This breaks standard keyboard navigation flows.
 **Action:** Always map the Escape key to the logical "Back" or "Quit" action in all full-screen menu scenes to provide a consistent and intuitive keyboard navigation experience.
+## 2026-05-18 - Pygame Cursor State Resets on Scene Switch\n**Learning:** The `SceneManager.switch_to` centrally resets the mouse cursor to `pygame.SYSTEM_CURSOR_ARROW`. Any custom cursor (like `pygame.SYSTEM_CURSOR_HAND`) set during a scene's initialization (`__init__`) will be immediately overwritten upon transitioning to that scene.\n**Action:** To maintain a custom cursor throughout a scene, it must be continuously evaluated or explicitly set during event handling, such as on `pygame.MOUSEMOTION`.

--- a/command_line_conflict/scenes/defeat.py
+++ b/command_line_conflict/scenes/defeat.py
@@ -23,8 +23,10 @@ class DefeatScene:
         Args:
             event: The pygame event to handle.
         """
-        if event.type == pygame.KEYDOWN:
-            if event.key == pygame.K_RETURN:
+        if event.type == pygame.MOUSEMOTION:
+            pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
+        elif event.type == pygame.KEYDOWN:
+            if event.key in (pygame.K_RETURN, pygame.K_ESCAPE):
                 self.game.scene_manager.switch_to("menu")
         elif event.type == pygame.MOUSEBUTTONDOWN:
             self.game.scene_manager.switch_to("menu")
@@ -52,7 +54,7 @@ class DefeatScene:
         pulse = (math.sin(self.time * 5) + 1) / 2
         color_val = 150 + int(105 * pulse)
         pulse_color = (color_val, color_val, color_val)
-        instruction_text = self.font.render("Press Enter or Click to return to the menu", True, pulse_color)
+        instruction_text = self.font.render("Press Enter/Esc or Click to return to the menu", True, pulse_color)
         instruction_rect = instruction_text.get_rect(
             center=(
                 self.game.screen.get_width() / 2,

--- a/command_line_conflict/scenes/victory.py
+++ b/command_line_conflict/scenes/victory.py
@@ -23,8 +23,10 @@ class VictoryScene:
         Args:
             event: The pygame event to handle.
         """
-        if event.type == pygame.KEYDOWN:
-            if event.key == pygame.K_RETURN:
+        if event.type == pygame.MOUSEMOTION:
+            pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
+        elif event.type == pygame.KEYDOWN:
+            if event.key in (pygame.K_RETURN, pygame.K_ESCAPE):
                 self.game.scene_manager.switch_to("menu")
         elif event.type == pygame.MOUSEBUTTONDOWN:
             self.game.scene_manager.switch_to("menu")
@@ -52,7 +54,7 @@ class VictoryScene:
         pulse = (math.sin(self.time * 5) + 1) / 2
         color_val = 150 + int(105 * pulse)
         pulse_color = (color_val, color_val, color_val)
-        instruction_text = self.font.render("Press Enter or Click to return to the menu", True, pulse_color)
+        instruction_text = self.font.render("Press Enter/Esc or Click to return to the menu", True, pulse_color)
         instruction_rect = instruction_text.get_rect(
             center=(
                 self.game.screen.get_width() / 2,


### PR DESCRIPTION
This PR implements small UX enhancements in the Defeat and Victory scenes based on feedback to make them more accessible and user-friendly. It handles keyboard navigation more consistently by adding `Escape` key support to return to the menu alongside `Enter`. It also ensures the hand cursor is correctly displayed by handling it on `pygame.MOUSEMOTION`, bypassing the `SceneManager`'s initialization override. Finally, the UI text was updated to reflect these interaction changes.

---
*PR created automatically by Jules for task [10276522430155922999](https://jules.google.com/task/10276522430155922999) started by @tsainez*