### PR TITLE
⚡ Bolt: Inline wall check in pathfinding inner loop to reduce function call overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2024-06-12 - [List Comprehension over Loop Append]
 **Learning:** In performance-critical Python paths (like per-frame rendering loops), initializing an empty list and calling `.append()` in a loop introduces significant overhead due to function lookup and execution. In `RenderingSystem.draw`, this slowed down spatial map filtering.
 **Action:** Replace empty list initialization and loop `.append()` with list comprehensions. List comprehensions are evaluated in C, avoiding the Python-level function call overhead, making iteration over sparse maps noticeably faster.
+
+## 2024-08-01 - [Avoid Python method call overhead in inner loops]
+**Learning:** In highly performant inner loops (like the `A*` pathfinding logic evaluating thousands of neighbor nodes), invoking an instance method (e.g., `self.is_blocked()`) incurs substantial Python call frame overhead.
+**Action:** Instead of invoking methods to access simple attributes, inline the logic (e.g., `(nx, ny) in walls`) and pre-cache the attributes (e.g., `walls = self.walls`) to local variables outside the loop to eliminate method lookups and dramatically improve execution time.

--- a/command_line_conflict/maps/base.py
+++ b/command_line_conflict/maps/base.py
@@ -115,6 +115,7 @@ class Map:
         height = self.height
         goal_x, goal_y = goal
         inf = float("inf")
+        walls = self.walls
 
         while open_set:
             # Security: Prevent infinite loops or excessive CPU usage
@@ -140,7 +141,8 @@ class Map:
                 if nx < 0 or nx >= width or ny < 0 or ny >= height:
                     continue
 
-                if not can_fly and self.is_blocked(nx, ny):
+                # Optimization: Inline self.is_blocked to avoid Python method call overhead
+                if not can_fly and (nx, ny) in walls:
                     continue
 
                 if extra_obstacles and (nx, ny) in extra_obstacles:


### PR DESCRIPTION
💡 What: Caches `self.walls` locally and inlines `self.is_blocked` to `(nx, ny) in walls` inside the inner loop of `A*` pathfinding in `Map.find_path`.
🎯 Why: `find_path` is called frequently. In Python, instance method calls have substantial overhead. Inlining this to a local set lookup avoids the call frame overhead and attribute lookup, making the inner loop significantly faster.
📊 Impact: Expected to reduce pathfinding execution time noticeably by removing thousands of unnecessary function calls per frame.
🔬 Measurement: Run A* intensive tests or profile AI movement and observe reduced overhead in `find_path`.

---
*PR created automatically by Jules for task [9055476156685039416](https://jules.google.com/task/9055476156685039416) started by @tsainez*