### PR TITLE
🎨 Palette: Fix Cursor State and Navigation in Defeat/Victory Scenes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -10,3 +10,9 @@
 ## 2026-05-17 - Missing Escape Key Navigation
 **Learning:** Some scenes (Settings, Menu) were missing `pygame.K_ESCAPE` handling, which is a common and expected UX pattern for navigating backwards or quitting in games. This breaks standard keyboard navigation flows.
 **Action:** Always map the Escape key to the logical "Back" or "Quit" action in all full-screen menu scenes to provide a consistent and intuitive keyboard navigation experience.
+## 2024-05-19 - Test Mocking Global State Pollution
+**Learning:** When testing UI enhancements in Pygame (like changing `pygame.mouse.set_cursor`), doing `pygame.mouse.set_cursor = MagicMock()` causes severe test pollution that can cascade to other tests since the module level mock is persistent. It fails the required pre commit steps for CI pipeline since tests pollute one another.
+**Action:** Always use `unittest.mock.patch("pygame.mouse.set_cursor")` to temporarily replace Pygame's global cursor setter within the test context to avoid leaking the mock to other tests.
+## 2024-05-19 - Global Cursor State Bleeding Across Scenes
+**Learning:** Updating a Pygame cursor without resetting it can result in global side effects. `SYSTEM_CURSOR_HAND` used in an end screen will bleed over into a main menu screen if standard scene transition methods don't proactively revert back to `SYSTEM_CURSOR_ARROW`.
+**Action:** The SceneManager or the new scene's initialization must reset cursor state, or individual scenes must reset it before initiating scene switching logic.

--- a/command_line_conflict/scenes/defeat.py
+++ b/command_line_conflict/scenes/defeat.py
@@ -23,8 +23,10 @@ class DefeatScene:
         Args:
             event: The pygame event to handle.
         """
-        if event.type == pygame.KEYDOWN:
-            if event.key == pygame.K_RETURN:
+        if event.type == pygame.MOUSEMOTION:
+            pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
+        elif event.type == pygame.KEYDOWN:
+            if event.key in (pygame.K_RETURN, pygame.K_ESCAPE):
                 self.game.scene_manager.switch_to("menu")
         elif event.type == pygame.MOUSEBUTTONDOWN:
             self.game.scene_manager.switch_to("menu")

--- a/command_line_conflict/scenes/defeat.py
+++ b/command_line_conflict/scenes/defeat.py
@@ -27,8 +27,10 @@ class DefeatScene:
             pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
         elif event.type == pygame.KEYDOWN:
             if event.key in (pygame.K_RETURN, pygame.K_ESCAPE):
+                pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
                 self.game.scene_manager.switch_to("menu")
         elif event.type == pygame.MOUSEBUTTONDOWN:
+            pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
             self.game.scene_manager.switch_to("menu")
 
     def update(self, dt):

--- a/command_line_conflict/scenes/victory.py
+++ b/command_line_conflict/scenes/victory.py
@@ -23,8 +23,10 @@ class VictoryScene:
         Args:
             event: The pygame event to handle.
         """
-        if event.type == pygame.KEYDOWN:
-            if event.key == pygame.K_RETURN:
+        if event.type == pygame.MOUSEMOTION:
+            pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
+        elif event.type == pygame.KEYDOWN:
+            if event.key in (pygame.K_RETURN, pygame.K_ESCAPE):
                 self.game.scene_manager.switch_to("menu")
         elif event.type == pygame.MOUSEBUTTONDOWN:
             self.game.scene_manager.switch_to("menu")

--- a/command_line_conflict/scenes/victory.py
+++ b/command_line_conflict/scenes/victory.py
@@ -27,8 +27,10 @@ class VictoryScene:
             pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
         elif event.type == pygame.KEYDOWN:
             if event.key in (pygame.K_RETURN, pygame.K_ESCAPE):
+                pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
                 self.game.scene_manager.switch_to("menu")
         elif event.type == pygame.MOUSEBUTTONDOWN:
+            pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
             self.game.scene_manager.switch_to("menu")
 
     def update(self, dt):

--- a/tests/unit/scenes/test_defeat_scene.py
+++ b/tests/unit/scenes/test_defeat_scene.py
@@ -2,6 +2,7 @@ import pygame
 from unittest.mock import MagicMock, patch
 from command_line_conflict.scenes.defeat import DefeatScene
 
+
 @patch("pygame.mouse.set_cursor")
 def test_defeat_scene_mousemotion_cursor(mock_set_cursor):
     """Test that moving the mouse in the defeat scene sets the cursor to a hand."""
@@ -15,6 +16,7 @@ def test_defeat_scene_mousemotion_cursor(mock_set_cursor):
     scene.handle_event(event)
 
     mock_set_cursor.assert_called_with(pygame.SYSTEM_CURSOR_HAND)
+
 
 @patch("pygame.mouse.set_cursor")
 def test_defeat_scene_escape_key(mock_set_cursor):
@@ -30,6 +32,7 @@ def test_defeat_scene_escape_key(mock_set_cursor):
 
     mock_set_cursor.assert_called_with(pygame.SYSTEM_CURSOR_ARROW)
     game_mock.scene_manager.switch_to.assert_called_with("menu")
+
 
 @patch("pygame.mouse.set_cursor")
 def test_defeat_scene_mouse_click(mock_set_cursor):

--- a/tests/unit/scenes/test_defeat_scene.py
+++ b/tests/unit/scenes/test_defeat_scene.py
@@ -1,0 +1,30 @@
+import pygame
+from unittest.mock import MagicMock, patch
+from command_line_conflict.scenes.defeat import DefeatScene
+
+@patch("pygame.mouse.set_cursor")
+def test_defeat_scene_mousemotion_cursor(mock_set_cursor):
+    """Test that moving the mouse in the defeat scene sets the cursor to a hand."""
+    game_mock = MagicMock()
+    scene = DefeatScene(game_mock)
+
+    # Create a dummy MOUSEMOTION event
+    event = MagicMock()
+    event.type = pygame.MOUSEMOTION
+
+    scene.handle_event(event)
+
+    mock_set_cursor.assert_called_with(pygame.SYSTEM_CURSOR_HAND)
+
+def test_defeat_scene_escape_key():
+    """Test that pressing ESCAPE switches to the menu."""
+    game_mock = MagicMock()
+    scene = DefeatScene(game_mock)
+
+    event = MagicMock()
+    event.type = pygame.KEYDOWN
+    event.key = pygame.K_ESCAPE
+
+    scene.handle_event(event)
+
+    game_mock.scene_manager.switch_to.assert_called_with("menu")

--- a/tests/unit/scenes/test_defeat_scene.py
+++ b/tests/unit/scenes/test_defeat_scene.py
@@ -1,5 +1,7 @@
-import pygame
 from unittest.mock import MagicMock, patch
+
+import pygame
+
 from command_line_conflict.scenes.defeat import DefeatScene
 
 

--- a/tests/unit/scenes/test_defeat_scene.py
+++ b/tests/unit/scenes/test_defeat_scene.py
@@ -16,8 +16,9 @@ def test_defeat_scene_mousemotion_cursor(mock_set_cursor):
 
     mock_set_cursor.assert_called_with(pygame.SYSTEM_CURSOR_HAND)
 
-def test_defeat_scene_escape_key():
-    """Test that pressing ESCAPE switches to the menu."""
+@patch("pygame.mouse.set_cursor")
+def test_defeat_scene_escape_key(mock_set_cursor):
+    """Test that pressing ESCAPE resets cursor and switches to the menu."""
     game_mock = MagicMock()
     scene = DefeatScene(game_mock)
 
@@ -27,4 +28,19 @@ def test_defeat_scene_escape_key():
 
     scene.handle_event(event)
 
+    mock_set_cursor.assert_called_with(pygame.SYSTEM_CURSOR_ARROW)
+    game_mock.scene_manager.switch_to.assert_called_with("menu")
+
+@patch("pygame.mouse.set_cursor")
+def test_defeat_scene_mouse_click(mock_set_cursor):
+    """Test that clicking resets cursor and switches to the menu."""
+    game_mock = MagicMock()
+    scene = DefeatScene(game_mock)
+
+    event = MagicMock()
+    event.type = pygame.MOUSEBUTTONDOWN
+
+    scene.handle_event(event)
+
+    mock_set_cursor.assert_called_with(pygame.SYSTEM_CURSOR_ARROW)
     game_mock.scene_manager.switch_to.assert_called_with("menu")

--- a/tests/unit/scenes/test_victory_scene.py
+++ b/tests/unit/scenes/test_victory_scene.py
@@ -2,6 +2,7 @@ import pygame
 from unittest.mock import MagicMock, patch
 from command_line_conflict.scenes.victory import VictoryScene
 
+
 @patch("pygame.mouse.set_cursor")
 def test_victory_scene_mousemotion_cursor(mock_set_cursor):
     """Test that moving the mouse in the victory scene sets the cursor to a hand."""
@@ -15,6 +16,7 @@ def test_victory_scene_mousemotion_cursor(mock_set_cursor):
     scene.handle_event(event)
 
     mock_set_cursor.assert_called_with(pygame.SYSTEM_CURSOR_HAND)
+
 
 @patch("pygame.mouse.set_cursor")
 def test_victory_scene_escape_key(mock_set_cursor):
@@ -30,6 +32,7 @@ def test_victory_scene_escape_key(mock_set_cursor):
 
     mock_set_cursor.assert_called_with(pygame.SYSTEM_CURSOR_ARROW)
     game_mock.scene_manager.switch_to.assert_called_with("menu")
+
 
 @patch("pygame.mouse.set_cursor")
 def test_victory_scene_mouse_click(mock_set_cursor):

--- a/tests/unit/scenes/test_victory_scene.py
+++ b/tests/unit/scenes/test_victory_scene.py
@@ -1,5 +1,7 @@
-import pygame
 from unittest.mock import MagicMock, patch
+
+import pygame
+
 from command_line_conflict.scenes.victory import VictoryScene
 
 

--- a/tests/unit/scenes/test_victory_scene.py
+++ b/tests/unit/scenes/test_victory_scene.py
@@ -1,0 +1,30 @@
+import pygame
+from unittest.mock import MagicMock, patch
+from command_line_conflict.scenes.victory import VictoryScene
+
+@patch("pygame.mouse.set_cursor")
+def test_victory_scene_mousemotion_cursor(mock_set_cursor):
+    """Test that moving the mouse in the victory scene sets the cursor to a hand."""
+    game_mock = MagicMock()
+    scene = VictoryScene(game_mock)
+
+    # Create a dummy MOUSEMOTION event
+    event = MagicMock()
+    event.type = pygame.MOUSEMOTION
+
+    scene.handle_event(event)
+
+    mock_set_cursor.assert_called_with(pygame.SYSTEM_CURSOR_HAND)
+
+def test_victory_scene_escape_key():
+    """Test that pressing ESCAPE switches to the menu."""
+    game_mock = MagicMock()
+    scene = VictoryScene(game_mock)
+
+    event = MagicMock()
+    event.type = pygame.KEYDOWN
+    event.key = pygame.K_ESCAPE
+
+    scene.handle_event(event)
+
+    game_mock.scene_manager.switch_to.assert_called_with("menu")

--- a/tests/unit/scenes/test_victory_scene.py
+++ b/tests/unit/scenes/test_victory_scene.py
@@ -16,8 +16,9 @@ def test_victory_scene_mousemotion_cursor(mock_set_cursor):
 
     mock_set_cursor.assert_called_with(pygame.SYSTEM_CURSOR_HAND)
 
-def test_victory_scene_escape_key():
-    """Test that pressing ESCAPE switches to the menu."""
+@patch("pygame.mouse.set_cursor")
+def test_victory_scene_escape_key(mock_set_cursor):
+    """Test that pressing ESCAPE resets cursor and switches to the menu."""
     game_mock = MagicMock()
     scene = VictoryScene(game_mock)
 
@@ -27,4 +28,19 @@ def test_victory_scene_escape_key():
 
     scene.handle_event(event)
 
+    mock_set_cursor.assert_called_with(pygame.SYSTEM_CURSOR_ARROW)
+    game_mock.scene_manager.switch_to.assert_called_with("menu")
+
+@patch("pygame.mouse.set_cursor")
+def test_victory_scene_mouse_click(mock_set_cursor):
+    """Test that clicking resets cursor and switches to the menu."""
+    game_mock = MagicMock()
+    scene = VictoryScene(game_mock)
+
+    event = MagicMock()
+    event.type = pygame.MOUSEBUTTONDOWN
+
+    scene.handle_event(event)
+
+    mock_set_cursor.assert_called_with(pygame.SYSTEM_CURSOR_ARROW)
     game_mock.scene_manager.switch_to.assert_called_with("menu")


### PR DESCRIPTION
This PR improves the UX in the `DefeatScene` and `VictoryScene`. Specifically, it addresses the missing cursor interactivity cues by changing the cursor to a hand when moving the mouse across the screen, signaling that it can be clicked to continue. Additionally, it maps the `Escape` key alongside `Return` to exit back to the menu, providing a more standard navigation flow for users. Included unit tests safely mock the global `pygame.mouse.set_cursor` to ensure regression testing without suite pollution.

---
*PR created automatically by Jules for task [16176820767743489791](https://jules.google.com/task/16176820767743489791) started by @tsainez*