### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input validation to steamworks achievement names

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -29,3 +29,7 @@
 **Vulnerability:** The developer cheats (F1 for reveal map, F2 for god mode) in GameScene were not gated by the DEBUG configuration flag.
 **Learning:** Even if a feature is intended only for development, it must be explicitly protected by a configuration check. Otherwise, it might be accessible in production builds.
 **Prevention:** Wrap all debug and cheat functionalities in a check against the relevant configuration flag (e.g., `if config.DEBUG:`).
+## 2025-05-20 - Unsanitized External API Input
+**Vulnerability:** The application passed user-controllable input (`achievement_name`) directly to an external API (`self.steam.SetAchievement()`) without any validation or sanitization.
+**Learning:** Even when the implementation of an external library is unknown or abstracted away, it is a critical defense-in-depth practice to validate and constrain all input parameters before passing them across the trust boundary.
+**Prevention:** Implement explicit input validation for all parameters passed to external APIs, enforcing a strict character allowlist (e.g., regex `^[A-Za-z0-9_]+$`) and a reasonable length limit.

--- a/command_line_conflict/steam_integration.py
+++ b/command_line_conflict/steam_integration.py
@@ -1,6 +1,7 @@
 """Steamworks integration for Command Line Conflict."""
 
 import re
+
 from .logger import log
 
 

--- a/command_line_conflict/steam_integration.py
+++ b/command_line_conflict/steam_integration.py
@@ -1,5 +1,6 @@
 """Steamworks integration for Command Line Conflict."""
 
+import re
 from .logger import log
 
 
@@ -31,6 +32,15 @@ class SteamIntegration:
         Args:
             achievement_name: The API name of the achievement to unlock.
         """
+        # Security: Validate achievement_name to prevent injection or DoS
+        if not achievement_name or len(achievement_name) > 64:
+            log.warning(f"Invalid achievement name length: {achievement_name}")
+            return
+
+        if not re.match(r"^[A-Za-z0-9_]+$", achievement_name):
+            log.warning(f"Invalid achievement name format: {achievement_name}")
+            return
+
         if not self.initialized or not self.steam:
             log.debug(f"Steam not initialized. Skipping achievement: {achievement_name}")
             return

--- a/tests/unit/test_steam_integration.py
+++ b/tests/unit/test_steam_integration.py
@@ -54,11 +54,15 @@ def test_unlock_achievement(mock_log):
 
 
 def test_unlock_achievement_not_initialized(mock_log):
-    with patch("builtins.__import__", side_effect=ImportError):
-        steam = SteamIntegration()
-        steam.unlock_achievement("TEST_ACHIEVEMENT")
-        assert steam.initialized is False
-        mock_log.debug.assert_called_with("Steam not initialized. Skipping achievement: TEST_ACHIEVEMENT")
+    with patch.dict(sys.modules):
+        if "steamworks" in sys.modules:
+            del sys.modules["steamworks"]
+
+        with patch("builtins.__import__", side_effect=ImportError):
+            steam = SteamIntegration()
+            steam.unlock_achievement("TEST_ACHIEVEMENT")
+            assert steam.initialized is False
+            mock_log.debug.assert_called_with("Steam not initialized. Skipping achievement: TEST_ACHIEVEMENT")
 
 
 def test_update(mock_log):


### PR DESCRIPTION
This PR adds input validation to the `unlock_achievement` method in `command_line_conflict/steam_integration.py`.

🚨 Severity: MEDIUM
💡 Vulnerability: The application passed an unsanitized string (`achievement_name`) directly to an external API (`self.steam.SetAchievement()`). While the exact vulnerability depends on the underlying Steamworks C++ implementation, this violates the principle of defense-in-depth and could lead to unexpected behavior or injection.
🎯 Impact: Depending on how the Steamworks library handles invalid data, passing excessively long strings or strings with special characters could potentially lead to a denial of service (DoS), memory corruption, or logic bugs.
🔧 Fix: Added a regex validation check (`^[A-Za-z0-9_]+$`) and a length limit (maximum 64 characters) to the `achievement_name` parameter before it is passed to the external API.
✅ Verification: Ran `python3 -m pytest tests` to verify the fix does not break existing functionality. Tests pass.

---
*PR created automatically by Jules for task [17627527213059214713](https://jules.google.com/task/17627527213059214713) started by @tsainez*