### PR TITLE
🎨 Palette: Fix cursor state and add Escape key mapping to full-screen scenes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-05-24 - Event-Driven Visual Effects
 **Learning:** Visual feedback (like floating damage text) often requires data from logic systems (Combat) but rendering in UI systems. Direct coupling creates spaghetti code. The Event Queue pattern is perfect here: Combat logic emits a "visual_effect" event, and the Scene routes it to the UI.
 **Action:** When adding new visual feedback triggered by game logic (e.g., healing numbers, level up flash), use `game_state.add_event({"type": "visual_effect", ...})` instead of calling UI methods directly.
+
+## 2024-05-24 - Consistent Cursor State Management
+**Learning:** Pygame custom cursors set during scene initialization (`__init__`) get overridden because the global `SceneManager.switch_to` centralized logic resets the cursor to an arrow upon transition.
+**Action:** When setting a custom cursor (like `SYSTEM_CURSOR_HAND`) for a full-screen scene, it must be continuously reapplied during event handling (e.g., on `pygame.MOUSEMOTION`) to ensure it persists throughout the scene's lifetime and maintains consistent UX.

--- a/command_line_conflict/scenes/defeat.py
+++ b/command_line_conflict/scenes/defeat.py
@@ -15,7 +15,6 @@ class DefeatScene:
         self.game = game
         self.font = game.font
         self.time = 0.0
-        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
 
     def handle_event(self, event):
         """Handles events for the defeat scene.
@@ -24,10 +23,12 @@ class DefeatScene:
             event: The pygame event to handle.
         """
         if event.type == pygame.KEYDOWN:
-            if event.key == pygame.K_RETURN:
+            if event.key in (pygame.K_RETURN, pygame.K_ESCAPE):
                 self.game.scene_manager.switch_to("menu")
         elif event.type == pygame.MOUSEBUTTONDOWN:
             self.game.scene_manager.switch_to("menu")
+        elif event.type == pygame.MOUSEMOTION:
+            pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
 
     def update(self, dt):
         """Updates the defeat scene.
@@ -52,7 +53,7 @@ class DefeatScene:
         pulse = (math.sin(self.time * 5) + 1) / 2
         color_val = 150 + int(105 * pulse)
         pulse_color = (color_val, color_val, color_val)
-        instruction_text = self.font.render("Press Enter or Click to return to the menu", True, pulse_color)
+        instruction_text = self.font.render("Press Enter, Escape, or Click to return to the menu", True, pulse_color)
         instruction_rect = instruction_text.get_rect(
             center=(
                 self.game.screen.get_width() / 2,

--- a/command_line_conflict/scenes/victory.py
+++ b/command_line_conflict/scenes/victory.py
@@ -15,7 +15,6 @@ class VictoryScene:
         self.game = game
         self.font = game.font
         self.time = 0.0
-        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
 
     def handle_event(self, event):
         """Handles events for the victory scene.
@@ -24,10 +23,12 @@ class VictoryScene:
             event: The pygame event to handle.
         """
         if event.type == pygame.KEYDOWN:
-            if event.key == pygame.K_RETURN:
+            if event.key in (pygame.K_RETURN, pygame.K_ESCAPE):
                 self.game.scene_manager.switch_to("menu")
         elif event.type == pygame.MOUSEBUTTONDOWN:
             self.game.scene_manager.switch_to("menu")
+        elif event.type == pygame.MOUSEMOTION:
+            pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
 
     def update(self, dt):
         """Updates the victory scene.
@@ -52,7 +53,7 @@ class VictoryScene:
         pulse = (math.sin(self.time * 5) + 1) / 2
         color_val = 150 + int(105 * pulse)
         pulse_color = (color_val, color_val, color_val)
-        instruction_text = self.font.render("Press Enter or Click to return to the menu", True, pulse_color)
+        instruction_text = self.font.render("Press Enter, Escape, or Click to return to the menu", True, pulse_color)
         instruction_rect = instruction_text.get_rect(
             center=(
                 self.game.screen.get_width() / 2,


### PR DESCRIPTION
Fixes the Pygame custom cursor state reset issue in `VictoryScene` and `DefeatScene` by reapplying it on `pygame.MOUSEMOTION`, adds `Escape` key mapping for consistent keyboard navigation, and updates the UI instructional text accordingly. Also adds a UX learning to `.jules/palette.md`.

---
*PR created automatically by Jules for task [12324274339490272738](https://jules.google.com/task/12324274339490272738) started by @tsainez*