### PR TITLE
🎨 Palette: Fix cursor state and add Escape key mapping to end-game scenes

### DIFF
--- a/command_line_conflict/scenes/defeat.py
+++ b/command_line_conflict/scenes/defeat.py
@@ -15,7 +15,6 @@ class DefeatScene:
         self.game = game
         self.font = game.font
         self.time = 0.0
-        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
 
     def handle_event(self, event):
         """Handles events for the defeat scene.
@@ -23,8 +22,10 @@ class DefeatScene:
         Args:
             event: The pygame event to handle.
         """
-        if event.type == pygame.KEYDOWN:
-            if event.key == pygame.K_RETURN:
+        if event.type == pygame.MOUSEMOTION:
+            pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
+        elif event.type == pygame.KEYDOWN:
+            if event.key in (pygame.K_RETURN, pygame.K_ESCAPE):
                 self.game.scene_manager.switch_to("menu")
         elif event.type == pygame.MOUSEBUTTONDOWN:
             self.game.scene_manager.switch_to("menu")

--- a/command_line_conflict/scenes/victory.py
+++ b/command_line_conflict/scenes/victory.py
@@ -15,7 +15,6 @@ class VictoryScene:
         self.game = game
         self.font = game.font
         self.time = 0.0
-        pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
 
     def handle_event(self, event):
         """Handles events for the victory scene.
@@ -23,8 +22,10 @@ class VictoryScene:
         Args:
             event: The pygame event to handle.
         """
-        if event.type == pygame.KEYDOWN:
-            if event.key == pygame.K_RETURN:
+        if event.type == pygame.MOUSEMOTION:
+            pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
+        elif event.type == pygame.KEYDOWN:
+            if event.key in (pygame.K_RETURN, pygame.K_ESCAPE):
                 self.game.scene_manager.switch_to("menu")
         elif event.type == pygame.MOUSEBUTTONDOWN:
             self.game.scene_manager.switch_to("menu")


### PR DESCRIPTION
🎨 **Palette: Improve Victory and Defeat screen keyboard and mouse interactions**

**💡 What:** 
- Modified the Victory and Defeat scenes so that the hand cursor (indicating click-to-continue) sets dynamically on `MOUSEMOTION` rather than on scene `__init__`.
- Added the `Escape` key as a valid way to dismiss the Victory and Defeat screens.

**🎯 Why:**
- Pygame's `SceneManager` centrally resets the cursor to the arrow upon a scene transition. As a result, the custom `SYSTEM_CURSOR_HAND` set in `__init__` was immediately getting overwritten, resulting in no interactive cursor feedback for the player. By shifting it to `MOUSEMOTION`, the interactive cursor works natively throughout the scene's lifetime.
- Adding the `Escape` key ensures keyboard navigation consistency, as users natively expect `Escape` to back out of full-screen prompts or menus (matching behavior in Settings and other menus). 

**♿ Accessibility:**
- Consistent keyboard mapping (`Enter` and `Escape`) makes the UI more predictable for keyboard-only users.
- Visible cursor feedback improves interaction affordances.

---
*PR created automatically by Jules for task [4006493764843669510](https://jules.google.com/task/4006493764843669510) started by @tsainez*