### PR TITLE
🎨 Palette: Accurate Tooltip Background Width

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -33,3 +33,6 @@
 ## 2024-05-24 - Event-Driven Visual Effects
 **Learning:** Visual feedback (like floating damage text) often requires data from logic systems (Combat) but rendering in UI systems. Direct coupling creates spaghetti code. The Event Queue pattern is perfect here: Combat logic emits a "visual_effect" event, and the Scene routes it to the UI.
 **Action:** When adding new visual feedback triggered by game logic (e.g., healing numbers, level up flash), use `game_state.add_event({"type": "visual_effect", ...})` instead of calling UI methods directly.
+## 2026-05-22 - Accurate Tooltip Width Calculation
+**Learning:** Pygame's `pygame.font.Font.size` provides exact text dimensions, replacing inaccurate character-count heuristics (`len(line) * multiplier`) for dynamic content like tooltips.
+**Action:** Always use `font.size(text)` when determining the bounding box for rendered text to ensure visual precision and avoid truncation or unnecessary whitespace.

--- a/command_line_conflict/systems/ui_system.py
+++ b/command_line_conflict/systems/ui_system.py
@@ -587,7 +587,8 @@ class UISystem:
         # Determine tooltip dimensions
         padding = 5
         line_height = 16
-        width = max(len(line) * 7 for line in lines) + padding * 2  # Approx width
+        max_text_width = max(self.small_font.size(line)[0] for line in lines) if lines else 0
+        width = max_text_width + padding * 2
         height = len(lines) * line_height + padding * 2
 
         x, y = screen_pos


### PR DESCRIPTION
Updated `draw_tooltip` in `ui_system.py` to use Pygame's `font.size()` instead of a heuristic multiplier. This ensures the tooltip background fits dynamic text precisely.

---
*PR created automatically by Jules for task [6954216800534553867](https://jules.google.com/task/6954216800534553867) started by @tsainez*