### PR TITLE
🎨 Palette: Add Helper Text Guidance to Menu Options

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -40,3 +40,6 @@
 ## 2026-05-22 - Accurate Tooltip Width Calculation
 **Learning:** Pygame's `pygame.font.Font.size` provides exact text dimensions, replacing inaccurate character-count heuristics (`len(line) * multiplier`) for dynamic content like tooltips.
 **Action:** Always use `font.size(text)` when determining the bounding box for rendered text to ensure visual precision and avoid truncation or unnecessary whitespace.
+## 2026-05-24 - Consistent Helper Text Guidance
+**Learning:** Pygame menus lacking contextual "helper text" can leave users guessing about the exact nature of options (e.g., "Continue Campaign" vs "New Game"). Using a pattern established in the `SettingsScene`, adding descriptive text to the `MenuScene` significantly boosts discoverability and accessibility.
+**Action:** When creating or modifying full-screen menus, define a dictionary mapping options to descriptive helper text strings. Render the string corresponding to the currently selected option consistently at the bottom of the screen to guide user intent and improve the menu's overall UX.

--- a/command_line_conflict/scenes/menu.py
+++ b/command_line_conflict/scenes/menu.py
@@ -29,6 +29,13 @@ class MenuScene:
             self.menu_options.insert(0, "Continue Campaign")
 
         self.selected_option = 0
+        self.help_texts = {
+            "Continue Campaign": "Resume your saved progress.",
+            "New Game": "Start a new campaign from the beginning.",
+            "Map Editor": "Create and edit custom levels.",
+            "Options": "Adjust game settings.",
+            "Quit": "Exit the game.",
+        }
         self.option_rects = []
         self.title_font = pygame.font.Font(None, 74)
         self.option_font = pygame.font.Font(None, 50)
@@ -156,3 +163,11 @@ class MenuScene:
             text_rect = text.get_rect(center=(self.game.screen.get_width() / 2, 300 + i * 60))
             screen.blit(text, text_rect)
             self.option_rects.append((text_rect, i))
+
+        # Draw helper text for the currently selected option
+        current_option = self.menu_options[self.selected_option]
+        help_text = self.help_texts.get(current_option, "")
+        if help_text:
+            help_surf = self.game.font.render(help_text, True, (150, 150, 150))
+            help_rect = help_surf.get_rect(center=(self.game.screen.get_width() / 2, self.game.screen.get_height() - 50))
+            screen.blit(help_surf, help_rect)


### PR DESCRIPTION
Adds descriptive helper texts to the `MenuScene` options.
By providing brief explanations for options like "Continue Campaign" vs "New Game" directly on the screen, this improves discoverability and UX, borrowing from an established pattern used in `SettingsScene`.

Also updated the Palette journal to record this learning for consistent application across the UI.

---
*PR created automatically by Jules for task [14195624190352398451](https://jules.google.com/task/14195624190352398451) started by @tsainez*