### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Unhandled TypeError in Steamworks Integration

### DIFF
--- a/command_line_conflict/steam_integration.py
+++ b/command_line_conflict/steam_integration.py
@@ -34,6 +34,10 @@ class SteamIntegration:
             achievement_name: The API name of the achievement to unlock.
         """
         # Security: Validate achievement_name to prevent injection or DoS
+        if not isinstance(achievement_name, str):
+            log.warning(f"Invalid achievement name type: {type(achievement_name)}")
+            return
+
         if not achievement_name or len(achievement_name) > 64:
             log.warning(f"Invalid achievement name length: {achievement_name}")
             return


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Unhandled TypeError in Steamworks Integration

**🚨 Severity:** MEDIUM
**💡 Vulnerability:** Unhandled `TypeError` caused by passing non-string inputs to the `unlock_achievement` method in `SteamIntegration`. Because `len(achievement_name)` was called without verifying the type, passing an integer or non-sized object would crash the application.
**🎯 Impact:** A malicious or erroneous internal call passing invalid types could crash the game unexpectedly, leading to a localized Denial of Service.
**🔧 Fix:** Added a type check (`isinstance(achievement_name, str)`) at the beginning of the `unlock_achievement` method. If the input is not a string, it logs a warning and returns early, preventing the exception.
**✅ Verification:** Verified by ensuring the automated test suite (`tests/security/test_steam_integration_security.py`) passes, confirming the validation catches incorrect types without crashing.

---
*PR created automatically by Jules for task [7192049563817889926](https://jules.google.com/task/7192049563817889926) started by @tsainez*