### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unhandled TypeError in Steam achievement processing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -33,3 +33,7 @@
 **Vulnerability:** The application passed user-controllable input (`achievement_name`) directly to an external API (`self.steam.SetAchievement()`) without any validation or sanitization.
 **Learning:** Even when the implementation of an external library is unknown or abstracted away, it is a critical defense-in-depth practice to validate and constrain all input parameters before passing them across the trust boundary.
 **Prevention:** Implement explicit input validation for all parameters passed to external APIs, enforcing a strict character allowlist (e.g., regex `^[A-Za-z0-9_]+$`) and a reasonable length limit.
+## 2026-05-18 - Steamworks Integration TypeError
+**Vulnerability:** Unhandled TypeError when processing Steam achievement names.
+**Learning:** Checking `len(achievement_name)` without first verifying its type can lead to unhandled exceptions (TypeError) if an unexpected type (e.g., an integer or boolean) is passed, potentially causing localized application crashes or DoS.
+**Prevention:** Always validate that external or user-provided input matches the expected data type (e.g., using `isinstance(input, str)`) before performing type-specific operations like `len()`.

--- a/command_line_conflict/steam_integration.py
+++ b/command_line_conflict/steam_integration.py
@@ -34,7 +34,7 @@ class SteamIntegration:
             achievement_name: The API name of the achievement to unlock.
         """
         # Security: Validate achievement_name to prevent injection or DoS
-        if not achievement_name or len(achievement_name) > 64:
+        if not isinstance(achievement_name, str) or not achievement_name or len(achievement_name) > 64:
             log.warning(f"Invalid achievement name length: {achievement_name}")
             return
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unhandled TypeError when processing Steam achievement names. If an unexpected type (e.g., an integer) was passed to `SteamIntegration.unlock_achievement`, evaluating `len()` caused a runtime crash.
🎯 **Impact:** Potential localized Denial of Service (DoS) / application crash due to unhandled exceptions when processing external input.
🔧 **Fix:** Added `not isinstance(achievement_name, str)` to the validation condition before checking the length, ensuring safe type handling.
✅ **Verification:** Ran `python3 -m pytest tests/security` to confirm the security test (`test_unlock_achievement_input_validation`) now passes successfully.

---
*PR created automatically by Jules for task [4139364688097810440](https://jules.google.com/task/4139364688097810440) started by @tsainez*