### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TypeValidation DoS in Steam API

### DIFF
--- a/command_line_conflict/steam_integration.py
+++ b/command_line_conflict/steam_integration.py
@@ -33,27 +33,19 @@ class SteamIntegration:
         Args:
             achievement_name: The API name of the achievement to unlock.
         """
-        # Security: Validate achievement_name to prevent injection or DoS
-        if not achievement_name or len(achievement_name) > 64:
-            log.warning(f"Invalid achievement name length: {achievement_name}")
-            return
-
-        if not re.match(r"^[A-Za-z0-9_]+$", achievement_name):
-            log.warning(f"Invalid achievement name format: {achievement_name}")
-            return
-
-        if not self.initialized or not self.steam:
-            log.debug(f"Steam not initialized. Skipping achievement: {achievement_name}")
-            return
-
         # Security check: Validate achievement_name to prevent injection or crashes
         # Allow only alphanumeric characters and underscores, max 64 characters
         if (
             not isinstance(achievement_name, str)
+            or not achievement_name
             or len(achievement_name) > 64
             or not re.match(r"^[A-Za-z0-9_]+$", achievement_name)
         ):
             log.warning(f"Security Warning: Invalid achievement name format rejected: {achievement_name}")
+            return
+
+        if not self.initialized or not self.steam:
+            log.debug(f"Steam not initialized. Skipping achievement: {achievement_name}")
             return
 
         try:


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `unlock_achievement` function within the Steam integration lacked proper type validation for the `achievement_name` parameter. If a non-string object (such as an integer) was supplied, it would evaluate the implicit `not achievement_name` boolean and then proceed to call `len()` on the object, resulting in a fatal unhandled `TypeError`.
🎯 **Impact**: Passing malformed inputs to this integration endpoint would crash the application, potentially serving as a Denial of Service attack vector.
🔧 **Fix**: Refactored the method to check `isinstance(achievement_name, str)` initially and consolidated it with the existing string format validations. Due to short-circuit boolean evaluation, if the input is not a string, the system immediately returns a security warning before subsequent tests fail. 
✅ **Verification**: Run `python3 -m pytest tests/security/test_steam_integration_security.py` to observe that it successfully tests integers and malformed inputs without raising an exception.

---
*PR created automatically by Jules for task [4446518520587237454](https://jules.google.com/task/4446518520587237454) started by @tsainez*