### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability on invalid steam achievement types

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -33,3 +33,7 @@
 **Vulnerability:** The application passed user-controllable input (`achievement_name`) directly to an external API (`self.steam.SetAchievement()`) without any validation or sanitization.
 **Learning:** Even when the implementation of an external library is unknown or abstracted away, it is a critical defense-in-depth practice to validate and constrain all input parameters before passing them across the trust boundary.
 **Prevention:** Implement explicit input validation for all parameters passed to external APIs, enforcing a strict character allowlist (e.g., regex `^[A-Za-z0-9_]+$`) and a reasonable length limit.
+## 2026-06-25 - [TypeError Crash on Invalid Steam Achievement Types]
+**Vulnerability:** A Denial of Service (DoS) vulnerability existed in `steam_integration.py` where passing non-string values (e.g., an integer) to `unlock_achievement` would crash the application when evaluating `len(achievement_name)`.
+**Learning:** Type checking must strictly precede length checks or string operations when validating untrusted or dynamic parameters, to prevent unhandled `TypeError` exceptions from crashing the system.
+**Prevention:** In parameter validation sequences, ensure `isinstance(val, str)` is evaluated before `len()` or `re.match()`.

--- a/command_line_conflict/steam_integration.py
+++ b/command_line_conflict/steam_integration.py
@@ -33,27 +33,23 @@ class SteamIntegration:
         Args:
             achievement_name: The API name of the achievement to unlock.
         """
-        # Security: Validate achievement_name to prevent injection or DoS
+        # Security check: Validate achievement_name to prevent injection or crashes
+        # Type check must happen before len() to avoid TypeErrors on int/None
+        if not isinstance(achievement_name, str):
+            log.warning(f"Security Warning: Invalid achievement name type rejected: {type(achievement_name)}")
+            return
+
+        # Allow only alphanumeric characters and underscores, max 64 characters
         if not achievement_name or len(achievement_name) > 64:
             log.warning(f"Invalid achievement name length: {achievement_name}")
             return
 
         if not re.match(r"^[A-Za-z0-9_]+$", achievement_name):
-            log.warning(f"Invalid achievement name format: {achievement_name}")
+            log.warning(f"Security Warning: Invalid achievement name format rejected: {achievement_name}")
             return
 
         if not self.initialized or not self.steam:
             log.debug(f"Steam not initialized. Skipping achievement: {achievement_name}")
-            return
-
-        # Security check: Validate achievement_name to prevent injection or crashes
-        # Allow only alphanumeric characters and underscores, max 64 characters
-        if (
-            not isinstance(achievement_name, str)
-            or len(achievement_name) > 64
-            or not re.match(r"^[A-Za-z0-9_]+$", achievement_name)
-        ):
-            log.warning(f"Security Warning: Invalid achievement name format rejected: {achievement_name}")
             return
 
         try:


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability on invalid steam achievement types

🚨 Severity: MEDIUM
💡 Vulnerability: The `unlock_achievement` method was vulnerable to a Denial of Service (DoS) crash due to a `TypeError` raised when executing `len()` on a non-string input. Additionally, there were redundant validation blocks that were hard to maintain.
🎯 Impact: If a non-string value (like an integer) was passed to the function, the game would crash.
🔧 Fix: Consolidated the security checks and enforced a type validation check (`isinstance(achievement_name, str)`) before evaluating `len()`.
✅ Verification: Ran `pytest tests/security/test_steam_integration_security.py` which now passes successfully.

---
*PR created automatically by Jules for task [18080616805069628813](https://jules.google.com/task/18080616805069628813) started by @tsainez*