### PR TITLE
🎨 Palette: Add rapid pagination via Page Up/Down to FileDialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,6 @@
 ## 2026-05-24 - Consistent Helper Text Guidance
 **Learning:** Pygame menus lacking contextual "helper text" can leave users guessing about the exact nature of options (e.g., "Continue Campaign" vs "New Game"). Using a pattern established in the `SettingsScene`, adding descriptive text to the `MenuScene` significantly boosts discoverability and accessibility.
 **Action:** When creating or modifying full-screen menus, define a dictionary mapping options to descriptive helper text strings. Render the string corresponding to the currently selected option consistently at the bottom of the screen to guide user intent and improve the menu's overall UX.
+## 2024-05-25 - Rapid Pagination for Scrollable UIs
+**Learning:** Pygame scrollable UI components (such as `FileDialog`) can become tedious to navigate using only single-step arrow keys or the mouse scroll wheel when dealing with large lists.
+**Action:** Always implement keyboard accessibility and rapid pagination support by handling `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` key events, leveraging internal navigation logic with a step size of the maximum visible items to enhance navigation speed.

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:

--- a/tests/unit/ui/test_file_dialog.py
+++ b/tests/unit/ui/test_file_dialog.py
@@ -114,6 +114,33 @@ class TestFileDialog:
         file_dialog.handle_event(event)
         assert file_dialog.input_text == ""
 
+    def test_keyboard_pagination(self, file_dialog):
+        # We need more files to test pagination properly
+        file_dialog.files = [f"map{i}.json" for i in range(20)]
+        file_dialog.max_visible_files = 10
+        file_dialog.input_text = "map0.json"
+
+        event = MagicMock()
+        event.type = pygame.KEYDOWN
+
+        # Test Page Down
+        event.key = pygame.K_PAGEDOWN
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "map10.json"
+
+        event.key = pygame.K_PAGEDOWN
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "map19.json"  # Max boundary
+
+        # Test Page Up
+        event.key = pygame.K_PAGEUP
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "map9.json"
+
+        event.key = pygame.K_PAGEUP
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "map0.json"  # Min boundary
+
     def test_escape_closes(self, file_dialog):
         event = MagicMock()
         event.type = pygame.KEYDOWN


### PR DESCRIPTION
💡 **What:** Added rapid pagination to the `FileDialog` component using `Page Up` and `Page Down` keys.
🎯 **Why:** To prevent users from having to tediously scroll through long lists of files one by one with arrow keys, significantly improving keyboard accessibility and overall speed.
♿ **Accessibility:** This directly addresses keyboard navigation limitations by bringing standard list navigation paradigms to our Pygame UI toolkit.
📸 **Before/After:** Not applicable (interaction update only).

Tests: Added `test_keyboard_pagination` in `tests/unit/ui/test_file_dialog.py` checking both limits and inner bounds. Also ran `pytest` and code formatters.

---
*PR created automatically by Jules for task [3452091575251933711](https://jules.google.com/task/3452091575251933711) started by @tsainez*