### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in Map loading

### DIFF
--- a/command_line_conflict/maps/base.py
+++ b/command_line_conflict/maps/base.py
@@ -402,10 +402,11 @@ class Map:
                     raise ValueError("Map file must be a regular file.")
 
                 # Security: Check file size to prevent DoS via memory exhaustion
-                if st.st_size > cls.MAX_FILE_SIZE:
+                content = f.read(cls.MAX_FILE_SIZE + 1)
+                if len(content) > cls.MAX_FILE_SIZE:
                     raise ValueError(f"Map file exceeds maximum allowed size ({cls.MAX_FILE_SIZE} bytes)")
 
-                data = json.load(f)
+                data = json.loads(content)
             return cls.from_dict(data)
         except OSError as e:
             raise ValueError(f"Could not open/read file: {e}") from e

--- a/tests/security/test_map_load_traversal.py
+++ b/tests/security/test_map_load_traversal.py
@@ -5,7 +5,7 @@ from command_line_conflict.maps.base import Map
 
 
 class TestMapLoadTraversal(unittest.TestCase):
-    @patch("json.load")
+    @patch("json.loads")
     @patch("command_line_conflict.maps.base.open")
     @patch("command_line_conflict.maps.base.os.stat")
     @patch("command_line_conflict.maps.base.os.path.realpath")

--- a/tests/security/test_map_security.py
+++ b/tests/security/test_map_security.py
@@ -98,9 +98,10 @@ class TestMapSecurity(unittest.TestCase):
 
         # Set size larger than limit (assuming 2MB limit)
         mock_st = MagicMock()
-        mock_st.st_size = 5 * 1024 * 1024  # 5MB
         mock_st.st_mode = stat.S_IFREG  # Regular file
         mock_fstat.return_value = mock_st
+
+        mock_file.read.return_value = "x" * (2 * 1024 * 1024 + 1) # Size larger than limit
 
         with self.assertRaises(ValueError) as cm:
             Map.load_from_file("large_map.json")

--- a/tests/security/test_map_security.py
+++ b/tests/security/test_map_security.py
@@ -101,7 +101,7 @@ class TestMapSecurity(unittest.TestCase):
         mock_st.st_mode = stat.S_IFREG  # Regular file
         mock_fstat.return_value = mock_st
 
-        mock_file.read.return_value = "x" * (2 * 1024 * 1024 + 1) # Size larger than limit
+        mock_file.read.return_value = "x" * (2 * 1024 * 1024 + 1)  # Size larger than limit
 
         with self.assertRaises(ValueError) as cm:
             Map.load_from_file("large_map.json")


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Time-of-Check to Time-of-Use (TOCTOU) race condition in `Map.load_from_file`. The code checked the file size with `os.fstat(f.fileno()).st_size` before opening it with `json.load`. An attacker could swap the file for a massive one between the check and the read, causing memory exhaustion (DoS).
🎯 Impact: Denial of Service via memory exhaustion if an attacker provides a malformed, massive map file and exploits the race condition.
🔧 Fix: Replaced `st.st_size` check with an atomic read operation `f.read(limit)`. Now, the length is enforced during the read, preventing the TOCTOU race condition.
✅ Verification: Ran `pytest tests/security/test_map_security.py` and the full test suite `pytest tests/` successfully. Modified `test_load_from_file_size_limit` to mock `read` appropriately.

---
*PR created automatically by Jules for task [4553016440100158819](https://jules.google.com/task/4553016440100158819) started by @tsainez*