### PR TITLE
🎨 Palette: Add PageUp/PageDown rapid pagination to FileDialog

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -11,3 +11,6 @@
 **Learning:** Some scenes (Settings, Menu) were missing `pygame.K_ESCAPE` handling, which is a common and expected UX pattern for navigating backwards or quitting in games. This breaks standard keyboard navigation flows.
 **Action:** Always map the Escape key to the logical "Back" or "Quit" action in all full-screen menu scenes to provide a consistent and intuitive keyboard navigation experience.
 ## 2026-05-18 - Pygame Cursor State Resets on Scene Switch\n**Learning:** The `SceneManager.switch_to` centrally resets the mouse cursor to `pygame.SYSTEM_CURSOR_ARROW`. Any custom cursor (like `pygame.SYSTEM_CURSOR_HAND`) set during a scene's initialization (`__init__`) will be immediately overwritten upon transitioning to that scene.\n**Action:** To maintain a custom cursor throughout a scene, it must be continuously evaluated or explicitly set during event handling, such as on `pygame.MOUSEMOTION`.
+## 2024-05-19 - Pygame Scrollable UI Pagination
+**Learning:** Keyboard accessibility and navigation speed in Pygame scrollable UI components (such as `FileDialog`) are severely impacted without rapid pagination support. Users have to press arrow keys repeatedly for long lists.
+**Action:** Implement rapid pagination support by handling `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` key events to scroll/navigate by the maximum visible items in scrollable components.

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:

--- a/tests/unit/ui/test_file_dialog.py
+++ b/tests/unit/ui/test_file_dialog.py
@@ -160,3 +160,24 @@ class TestFileDialog:
         file_dialog.handle_event(event)
         assert file_dialog.hovered_element is None
         assert file_dialog.hovered_file_index is None
+
+    def test_keyboard_pagination(self, file_dialog):
+        # file_dialog already has "map1.json", "map2.json". Let's add more to test pagination
+        for i in range(3, 20):
+            file_dialog.files.append(f"map{i}.json")
+
+        file_dialog.input_text = "map1.json" # index 0
+
+        event = MagicMock()
+        event.type = pygame.KEYDOWN
+
+        event.key = pygame.K_PAGEDOWN
+        file_dialog.handle_event(event)
+
+        # max_visible_files is 10, so index 0 + 10 = 10, which is "map11.json"
+        # map1.json (0), map2.json (1), map3.json (2), ... map11.json (10)
+        assert file_dialog.input_text == "map11.json"
+
+        event.key = pygame.K_PAGEUP
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "map1.json"

--- a/tests/unit/ui/test_file_dialog.py
+++ b/tests/unit/ui/test_file_dialog.py
@@ -166,7 +166,7 @@ class TestFileDialog:
         for i in range(3, 20):
             file_dialog.files.append(f"map{i}.json")
 
-        file_dialog.input_text = "map1.json" # index 0
+        file_dialog.input_text = "map1.json"  # index 0
 
         event = MagicMock()
         event.type = pygame.KEYDOWN


### PR DESCRIPTION
**💡 What:** Added `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` event handling to the `FileDialog` component to allow users to rapidly page through long lists of files.
**🎯 Why:** Currently, users have to press the arrow keys repeatedly or use the mouse scroll wheel to navigate through file lists. This is a tedious and inaccessible experience, especially for users who rely solely on keyboard navigation. Implementing rapid pagination significantly improves the usability of the scrollable UI.
**📸 Before/After:** N/A (Functional change).
**♿ Accessibility:** Vastly improves keyboard navigation speed for screen-reader or keyboard-only users interacting with long scrollable lists by minimizing the number of keystrokes required.

---
*PR created automatically by Jules for task [319634205743126834](https://jules.google.com/task/319634205743126834) started by @tsainez*