### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in Map.load_from_file

### DIFF
--- a/command_line_conflict/maps/base.py
+++ b/command_line_conflict/maps/base.py
@@ -401,11 +401,12 @@ class Map:
                 if not stat.S_ISREG(st.st_mode):
                     raise ValueError("Map file must be a regular file.")
 
-                # Security: Check file size to prevent DoS via memory exhaustion
-                if st.st_size > cls.MAX_FILE_SIZE:
+                # Security: Check file size to prevent DoS via memory exhaustion (atomic read prevents TOCTOU)
+                content = f.read(cls.MAX_FILE_SIZE + 1)
+                if len(content) > cls.MAX_FILE_SIZE:
                     raise ValueError(f"Map file exceeds maximum allowed size ({cls.MAX_FILE_SIZE} bytes)")
 
-                data = json.load(f)
+                data = json.loads(content)
             return cls.from_dict(data)
         except OSError as e:
             raise ValueError(f"Could not open/read file: {e}") from e

--- a/tests/security/test_map_load_traversal.py
+++ b/tests/security/test_map_load_traversal.py
@@ -5,11 +5,11 @@ from command_line_conflict.maps.base import Map
 
 
 class TestMapLoadTraversal(unittest.TestCase):
-    @patch("json.load")
+    @patch("json.loads")
     @patch("command_line_conflict.maps.base.open")
     @patch("command_line_conflict.maps.base.os.stat")
     @patch("command_line_conflict.maps.base.os.path.realpath")
-    def test_load_from_unauthorized_location(self, mock_realpath, mock_stat, mock_open, mock_json_load):
+    def test_load_from_unauthorized_location(self, mock_realpath, mock_stat, mock_open, mock_json_loads):
         """Verify that loading map from unauthorized location raises ValueError."""
         # Setup mocks to simulate a valid file in an unauthorized location
         unauthorized_path = "/etc/passwd"  # Example unauthorized path
@@ -24,7 +24,10 @@ class TestMapLoadTraversal(unittest.TestCase):
         mock_stat.return_value = mock_st
 
         # Mock open/json to return valid map data
-        mock_json_load.return_value = {"width": 10, "height": 10, "walls": []}
+        mock_file = MagicMock()
+        mock_file.read.return_value = "{}"
+        mock_open.return_value.__enter__.return_value = mock_file
+        mock_json_loads.return_value = {"width": 10, "height": 10, "walls": []}
 
         # This call SHOULD fail with ValueError due to path traversal check
         try:

--- a/tests/security/test_map_security.py
+++ b/tests/security/test_map_security.py
@@ -94,11 +94,10 @@ class TestMapSecurity(unittest.TestCase):
         # Create a mock file object
         mock_file = MagicMock()
         mock_file.fileno.return_value = 123
+        mock_file.read.return_value = "x" * (Map.MAX_FILE_SIZE + 2)
         mock_open.return_value.__enter__.return_value = mock_file
 
-        # Set size larger than limit (assuming 2MB limit)
         mock_st = MagicMock()
-        mock_st.st_size = 5 * 1024 * 1024  # 5MB
         mock_st.st_mode = stat.S_IFREG  # Regular file
         mock_fstat.return_value = mock_st
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A Time-of-Check to Time-of-Use (TOCTOU) race condition in `Map.load_from_file`. The code checked the file size with `os.fstat` before parsing it via `json.load`. An attacker could swap the file for a massive one between the check and the read, causing memory exhaustion (DoS).
🎯 Impact: Denial of Service via memory exhaustion (DoS).
🔧 Fix: Switched from using `json.load(f)` to atomically reading up to the limit using `f.read(cls.MAX_FILE_SIZE + 1)` and parsing it with `json.loads(content)`.
✅ Verification: `python3 -m pytest tests/security/test_map_security.py` passes successfully, validating the file size correctly limits the read content limit natively.

---
*PR created automatically by Jules for task [3124765550929774594](https://jules.google.com/task/3124765550929774594) started by @tsainez*