### PR TITLE
🎨 Palette: [UX improvement] Add pagination to File Dialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,7 @@
 ## 2026-05-24 - Consistent Helper Text Guidance
 **Learning:** Pygame menus lacking contextual "helper text" can leave users guessing about the exact nature of options (e.g., "Continue Campaign" vs "New Game"). Using a pattern established in the `SettingsScene`, adding descriptive text to the `MenuScene` significantly boosts discoverability and accessibility.
 **Action:** When creating or modifying full-screen menus, define a dictionary mapping options to descriptive helper text strings. Render the string corresponding to the currently selected option consistently at the bottom of the screen to guide user intent and improve the menu's overall UX.
+
+## 2024-05-25 - Rapid Pagination for Scrollable Lists
+**Learning:** In custom Pygame UI components like a `FileDialog`, relying solely on single-item arrow key navigation is tedious for long lists, reducing accessibility. Mouse users can use the scroll wheel, but keyboard users lack a fast navigation method.
+**Action:** Implement rapid pagination using `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` keys to jump by the maximum visible items (e.g., `max_visible_files`). Also, ensure mouse scrolling triggers logical selection updates instead of just visual scrolling by tying it to the same internal `_navigate()` method.

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -115,9 +115,9 @@ class FileDialog:
                     return self._confirm_selection()
 
             elif event.button == 4:  # Scroll up
-                self.scroll_offset = max(0, self.scroll_offset - 1)
+                self._navigate(-1)
             elif event.button == 5:  # Scroll down
-                self.scroll_offset = min(max(0, len(self.files) - self.max_visible_files), self.scroll_offset + 1)
+                self._navigate(1)
 
         elif event.type == pygame.KEYDOWN:
             if event.key == pygame.K_ESCAPE:
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:

--- a/tests/unit/ui/test_file_dialog.py
+++ b/tests/unit/ui/test_file_dialog.py
@@ -122,6 +122,71 @@ class TestFileDialog:
         file_dialog.handle_event(event)
         assert file_dialog.active is False
 
+    def test_pagination(self, file_dialog):
+        # We only have 2 files by default. Let's add more to test pagination properly.
+        for i in range(15):
+            with open(os.path.join(file_dialog.initial_dir, f"test_map_{i}.json"), "w") as f:
+                f.write("{}")
+
+        file_dialog.refresh_files()
+
+        # Start at 0
+        assert file_dialog.input_text == ""
+
+        event = MagicMock()
+        event.type = pygame.KEYDOWN
+
+        # Navigate to first item
+        event.key = pygame.K_DOWN
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "map1.json"
+
+        # Page down (jumps by max_visible_files, which is 10)
+        event.key = pygame.K_PAGEDOWN
+        file_dialog.handle_event(event)
+        # Should be index 0 + 10 = 10, which is "test_map_1.json" (sorted)
+        # Files: map1.json, map2.json, test_map_0.json, test_map_1.json, ... test_map_14.json
+        # 0: map1.json
+        # 10: test_map_13.json (wait, sorting is alphabetic)
+        # let's just check it jumped by checking the index.
+        current_idx = file_dialog.files.index(file_dialog.input_text)
+        assert current_idx == 10
+
+        # Page up (jumps back by 10)
+        event.key = pygame.K_PAGEUP
+        file_dialog.handle_event(event)
+        current_idx = file_dialog.files.index(file_dialog.input_text)
+        assert current_idx == 0
+
+    def test_mouse_scrolling(self, file_dialog):
+        for i in range(15):
+            with open(os.path.join(file_dialog.initial_dir, f"test_map_{i}.json"), "w") as f:
+                f.write("{}")
+
+        file_dialog.refresh_files()
+
+        # Start at 0
+        event = MagicMock()
+        event.type = pygame.KEYDOWN
+        event.key = pygame.K_DOWN
+        file_dialog.handle_event(event)
+
+        # Scroll down
+        scroll_event = MagicMock()
+        scroll_event.type = pygame.MOUSEBUTTONDOWN
+        scroll_event.button = 5
+        file_dialog.handle_event(scroll_event)
+
+        current_idx = file_dialog.files.index(file_dialog.input_text)
+        assert current_idx == 1
+
+        # Scroll up
+        scroll_event.button = 4
+        file_dialog.handle_event(scroll_event)
+
+        current_idx = file_dialog.files.index(file_dialog.input_text)
+        assert current_idx == 0
+
     def test_hover_states(self, file_dialog):
         # Move over close button
         event = MagicMock()


### PR DESCRIPTION
**💡 What**
Added keyboard pagination support (`Page Up` and `Page Down`) to the `FileDialog` component and refactored mouse wheel scrolling to use the internal `_navigate()` method.

**🎯 Why**
Previously, navigating long lists in the file dialog was tedious for keyboard users who had to use the arrow keys to move one item at a time. This change significantly speeds up keyboard navigation. Additionally, mouse wheel scrolling previously only scrolled the visual viewport but didn't update the logical selection, which could lead to users confirming actions on off-screen items. Tying scroll wheels to `_navigate()` fixes this UX gap.

**📸 Before/After**
N/A (Interaction change, no visual layout changes).

**♿ Accessibility**
Improves keyboard accessibility by providing rapid pagination keys, bridging the gap between mouse scroll speed and keyboard navigation speed.

---
*PR created automatically by Jules for task [2180947170118179541](https://jules.google.com/task/2180947170118179541) started by @tsainez*