### PR TITLE
🎨 Palette: Add keyboard pagination to FileDialog

### DIFF
--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:

--- a/tests/unit/ui/test_file_dialog.py
+++ b/tests/unit/ui/test_file_dialog.py
@@ -160,3 +160,31 @@ class TestFileDialog:
         file_dialog.handle_event(event)
         assert file_dialog.hovered_element is None
         assert file_dialog.hovered_file_index is None
+
+    def test_keyboard_pagination(self, file_dialog):
+        # Add more files to exceed max_visible_files (10)
+        file_dialog.files = [f"map{i}.json" for i in range(20)]
+        file_dialog.input_text = "map0.json"
+
+        event = MagicMock()
+        event.type = pygame.KEYDOWN
+
+        # Test Page Down
+        event.key = pygame.K_PAGEDOWN
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "map10.json"
+
+        # Test Page Up
+        event.key = pygame.K_PAGEUP
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "map0.json"
+
+        # Test boundary - Page Up from start
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "map0.json"
+
+        # Test boundary - Page Down to end
+        file_dialog.input_text = "map15.json"
+        event.key = pygame.K_PAGEDOWN
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "map19.json"


### PR DESCRIPTION
### 💡 What
Added support for rapid keyboard pagination inside the custom Pygame `FileDialog` component using `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN`.

### 🎯 Why
Long lists of files can be tedious to scroll through one by one using just `K_UP` and `K_DOWN`. Adding pagination vastly improves accessibility and interaction speed for users who prefer or rely on keyboard navigation.

### 📸 Before/After
**Before:**
Users had to hold the Up or Down arrow key to scroll through long lists, moving one item per frame.

**After:**
Users can press Page Up or Page Down to instantly jump an entire viewable section (10 items) up or down, allowing them to rapidly skip through extensive directory contents.

### ♿ Accessibility
Keyboard-only users can now rapidly paginate through lists without needing to use mouse scrollwheels, making the `FileDialog` component fully usable and efficient purely via keyboard input.

---
*PR created automatically by Jules for task [1499210361487923697](https://jules.google.com/task/1499210361487923697) started by @tsainez*