### PR TITLE
🎨 Palette: Add rapid keyboard pagination to FileDialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,7 @@
 ## 2026-05-24 - Consistent Helper Text Guidance
 **Learning:** Pygame menus lacking contextual "helper text" can leave users guessing about the exact nature of options (e.g., "Continue Campaign" vs "New Game"). Using a pattern established in the `SettingsScene`, adding descriptive text to the `MenuScene` significantly boosts discoverability and accessibility.
 **Action:** When creating or modifying full-screen menus, define a dictionary mapping options to descriptive helper text strings. Render the string corresponding to the currently selected option consistently at the bottom of the screen to guide user intent and improve the menu's overall UX.
+
+## 2024-06-12 - Rapid Pagination for Large File Lists
+**Learning:** Keyboard navigation through long lists one item at a time is slow and frustrating. This is an accessibility issue for users who rely on keyboard navigation, as it lacks a way to jump through pages.
+**Action:** Added `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` handlers to `FileDialog` using `self._navigate(-self.max_visible_files)` and `self._navigate(self.max_visible_files)` to provide rapid pagination capabilities.

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:

--- a/tests/unit/ui/test_file_dialog.py
+++ b/tests/unit/ui/test_file_dialog.py
@@ -160,3 +160,21 @@ class TestFileDialog:
         file_dialog.handle_event(event)
         assert file_dialog.hovered_element is None
         assert file_dialog.hovered_file_index is None
+
+    def test_keyboard_pagination(self, file_dialog):
+        # We need more files to test pagination properly
+        file_dialog.files = [f"map{i}.json" for i in range(20)]
+        file_dialog.input_text = file_dialog.files[0]
+
+        event = MagicMock()
+        event.type = pygame.KEYDOWN
+
+        # Test Page Down
+        event.key = pygame.K_PAGEDOWN
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == file_dialog.files[10]
+
+        # Test Page Up
+        event.key = pygame.K_PAGEUP
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == file_dialog.files[0]


### PR DESCRIPTION
💡 **What:** 
Added support for `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` to the `FileDialog` component to allow users to scroll up and down by an entire page of visible files at a time.

🎯 **Why:** 
Scrolling through long lists of files one by one using just the up and down arrow keys can be extremely slow and frustrating. The lack of standard pagination keys significantly hampered navigation speed. 

♿ **Accessibility:**
Provides critical rapid-navigation alternatives for users who rely exclusively on a keyboard to navigate the UI, reducing keystroke fatigue and improving overall usability.

📸 **Before/After:**
- **Before:** Keyboard users had to press the Down arrow 50 times to scroll through a list of 50 files.
- **After:** Keyboard users can press Page Down 5 times to traverse the same 50-file list.

---
*PR created automatically by Jules for task [2412260473075409337](https://jules.google.com/task/2412260473075409337) started by @tsainez*