### PR TITLE
🎨 Palette: [UX improvement] Add keyboard pagination support to file dialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,6 @@
 ## 2026-05-24 - Consistent Helper Text Guidance
 **Learning:** Pygame menus lacking contextual "helper text" can leave users guessing about the exact nature of options (e.g., "Continue Campaign" vs "New Game"). Using a pattern established in the `SettingsScene`, adding descriptive text to the `MenuScene` significantly boosts discoverability and accessibility.
 **Action:** When creating or modifying full-screen menus, define a dictionary mapping options to descriptive helper text strings. Render the string corresponding to the currently selected option consistently at the bottom of the screen to guide user intent and improve the menu's overall UX.
+## 2024-05-24 - FileDialog Pagination Accessibility
+**Learning:** Pygame `FileDialog` components with long lists severely limit keyboard accessibility without rapid pagination keys (Page Up / Page Down). Re-using existing robust internal navigation (`_navigate`) simplifies the implementation.
+**Action:** When creating or modifying scrollable UI components in Pygame, ensure `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` are mapped to pagination functions.

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:

--- a/tests/unit/ui/test_file_dialog.py
+++ b/tests/unit/ui/test_file_dialog.py
@@ -160,3 +160,19 @@ class TestFileDialog:
         file_dialog.handle_event(event)
         assert file_dialog.hovered_element is None
         assert file_dialog.hovered_file_index is None
+
+    def test_pagination(self, file_dialog):
+        # Create enough files to paginate
+        file_dialog.files = [f"file_{i}.json" for i in range(20)]
+        file_dialog.input_text = "file_0.json"
+
+        event = MagicMock()
+        event.type = pygame.KEYDOWN
+        event.key = pygame.K_PAGEDOWN
+
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "file_10.json"
+
+        event.key = pygame.K_PAGEUP
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "file_0.json"


### PR DESCRIPTION
💡 What: Added `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` support to the file dialog, allowing the user to skip pages of files.
🎯 Why: Navigating long lists of files line-by-line using arrow keys is tedious and inaccessible; page-skipping greatly improves navigation speed and UX.
♿ Accessibility: Improved keyboard accessibility by enabling rapid navigation (pagination) matching standard OS conventions.

---
*PR created automatically by Jules for task [16455154442545736093](https://jules.google.com/task/16455154442545736093) started by @tsainez*