### PR TITLE
🎨 Palette: Add keyboard pagination to FileDialog

### DIFF
--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:

--- a/tests/unit/ui/test_file_dialog.py
+++ b/tests/unit/ui/test_file_dialog.py
@@ -220,25 +220,3 @@ class TestFileDialog:
         file_dialog.handle_event(event)
         assert file_dialog.hovered_element is None
         assert file_dialog.hovered_file_index is None
-
-    def test_pagination(self, file_dialog):
-        # Create enough dummy files to trigger scrolling
-        file_dialog.files = [f"file{i}.json" for i in range(20)]
-        file_dialog.input_text = "file0.json"
-
-        event = MagicMock()
-        event.type = pygame.KEYDOWN
-
-        # Test Page Down
-        event.key = pygame.K_PAGEDOWN
-        file_dialog.handle_event(event)
-
-        # file0.json is index 0. + max_visible_files (10) -> index 10
-        assert file_dialog.input_text == f"file{file_dialog.max_visible_files}.json"
-
-        # Test Page Up
-        event.key = pygame.K_PAGEUP
-        file_dialog.handle_event(event)
-
-        # Go back to index 0
-        assert file_dialog.input_text == "file0.json"

--- a/tests/unit/ui/test_file_dialog_ux.py
+++ b/tests/unit/ui/test_file_dialog_ux.py
@@ -59,3 +59,29 @@ class TestFileDialogUX:
         # and then reset to None
         mock_screen.set_clip.assert_any_call(empty_file_dialog.input_rect)
         mock_screen.set_clip.assert_any_call(None)
+
+    def test_pagination_keyboard_navigation(self, empty_file_dialog):
+        """Test that PAGEUP and PAGEDOWN navigate the file list by max_visible_files."""
+        import pygame
+
+        empty_file_dialog.files = [f"file{i}.json" for i in range(30)]
+        empty_file_dialog.max_visible_files = 10
+        empty_file_dialog.input_text = "file0.json"
+
+        # Test PAGEDOWN
+        event_pagedown = MagicMock()
+        event_pagedown.type = pygame.KEYDOWN
+        event_pagedown.key = pygame.K_PAGEDOWN
+        event_pagedown.unicode = ""
+
+        empty_file_dialog.handle_event(event_pagedown)
+        assert empty_file_dialog.input_text == "file10.json"
+
+        # Test PAGEUP
+        event_pageup = MagicMock()
+        event_pageup.type = pygame.KEYDOWN
+        event_pageup.key = pygame.K_PAGEUP
+        event_pageup.unicode = ""
+
+        empty_file_dialog.handle_event(event_pageup)
+        assert empty_file_dialog.input_text == "file0.json"


### PR DESCRIPTION
**💡 What**
Added support for `Page Up` and `Page Down` keyboard navigation in the `FileDialog` UI component. 

**🎯 Why**
Previously, users with large map directories had to manually press the `Down` arrow key (or scroll the mouse wheel) many times to reach the bottom of the list. By implementing pagination keys, users can rapidly navigate through the list by exactly the number of currently visible items (e.g., jumping 10 files at a time).

**📸 Before/After**
* Before: `Page Up` and `Page Down` keys had no effect in the file dialog.
* After: Pressing `Page Down` skips ahead by 10 items (or to the end), and `Page Up` skips back by 10 items (or to the top).

**♿ Accessibility**
Improves keyboard navigation and reduces repetitive strain by drastically lowering the number of keystrokes required to navigate long, scrollable lists.

---
*PR created automatically by Jules for task [1033748118655505393](https://jules.google.com/task/1033748118655505393) started by @tsainez*