### PR TITLE
⚡ Bolt: Optimize win/loss checks with early returns

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2024-06-14 - [Optimize Distance Checks and Vector Math]
 **Learning:** In performance-critical vector math (like movement updates and fleeing checks calculated per-entity per-frame), calculating `math.sqrt()` is relatively expensive. Often we only need to know if the distance is below a threshold or non-zero. Additionally, dividing multiple coordinate deltas (`dx / dist`, `dy / dist`) introduces redundant division overhead.
 **Action:** Replace `math.sqrt()` with squared distance calculations (`dist_sq = dx * dx + dy * dy`) and compare against squared thresholds for early exits. When square roots are necessary, calculate them once and pre-calculate a multiplication ratio (`step_ratio = (speed * dt) / dist`) to apply to all coordinate deltas.
+## 2024-06-15 - [Early Return in Win/Loss Checks]
+**Learning:** When iterating over ECS entities to evaluate boolean satisfaction (e.g., win/loss checks), accumulating a total count forces the system to iterate through every single entity (O(N) operation).
+**Action:** Use an early return (`return False/True`) upon finding the first match. This avoids iterating the entire collection, effectively converting an O(N) operation to O(1) in the average case.

--- a/command_line_conflict/scenes/game.py
+++ b/command_line_conflict/scenes/game.py
@@ -577,7 +577,6 @@ class GameScene:
         Returns:
             True if the win condition is met, False otherwise.
         """
-        enemy_count = 0
         for entity_id in self.game_state.get_entities_with_component(Player):
             components = self.game_state.entities.get(entity_id)
             if not components:
@@ -588,25 +587,24 @@ class GameScene:
                 if self.has_player_2_opponent and player.player_id == config.NEUTRAL_PLAYER_ID:
                     continue
                 if Health in components:
-                    enemy_count += 1
+                    # Optimization: Early return on first enemy found, avoiding O(N) iteration
+                    return False
 
-        if enemy_count == 0:
-            log.info("Victory! Mission Complete.")
-            self.game.steam.unlock_achievement("VICTORY")
-            # Trigger victory sound (note: scene switch might cut it off if SoundSystem isn't persistent or updated)
-            # Since SoundSystem is part of GameScene, and we switch scene, we should ideally play it in the new scene
-            # or ensure the sound continues. For now, we emit the event.
-            # But wait, if we switch immediately, update won't process events.
-            # However, GameScene.update processes systems then checks win.
-            # So the event might be lost if we don't process it.
-            # Actually, SoundSystem.update is called BEFORE check_win_condition in update().
-            # So if we add event here, it won't be processed until NEXT frame's SoundSystem.update.
-            # But next frame we are in VictoryScene.
-            # So we should play it directly via self.sound_system.play_sound("victory") to ensure it starts.
-            self.sound_system.play_sound("victory")
-            self.campaign_manager.complete_mission(self.current_mission_id)
-            return True
-        return False
+        log.info("Victory! Mission Complete.")
+        self.game.steam.unlock_achievement("VICTORY")
+        # Trigger victory sound (note: scene switch might cut it off if SoundSystem isn't persistent or updated)
+        # Since SoundSystem is part of GameScene, and we switch scene, we should ideally play it in the new scene
+        # or ensure the sound continues. For now, we emit the event.
+        # But wait, if we switch immediately, update won't process events.
+        # However, GameScene.update processes systems then checks win.
+        # So the event might be lost if we don't process it.
+        # Actually, SoundSystem.update is called BEFORE check_win_condition in update().
+        # So if we add event here, it won't be processed until NEXT frame's SoundSystem.update.
+        # But next frame we are in VictoryScene.
+        # So we should play it directly via self.sound_system.play_sound("victory") to ensure it starts.
+        self.sound_system.play_sound("victory")
+        self.campaign_manager.complete_mission(self.current_mission_id)
+        return True
 
     def check_loss_condition(self) -> bool:
         """Checks if the player has lost the level.
@@ -614,7 +612,6 @@ class GameScene:
         Returns:
             True if the loss condition is met, False otherwise.
         """
-        player_entity_count = 0
         for entity_id in self.game_state.get_entities_with_component(Player):
             components = self.game_state.entities.get(entity_id)
             if not components:
@@ -624,14 +621,13 @@ class GameScene:
             if player and player.is_human:
                 # Check for any player-controlled entity (unit or building)
                 if Health in components:
-                    player_entity_count += 1
+                    # Optimization: Early return on first friendly found, avoiding O(N) iteration
+                    return False
 
-        if player_entity_count == 0:
-            log.info("Defeat! Mission Failed.")
-            self.game.steam.unlock_achievement("DEFEAT")
-            self.sound_system.play_sound("defeat")
-            return True
-        return False
+        log.info("Defeat! Mission Failed.")
+        self.game.steam.unlock_achievement("DEFEAT")
+        self.sound_system.play_sound("defeat")
+        return True
 
     def draw(self, screen):
         """Draws the entire game scene.


### PR DESCRIPTION
### 💡 What
Updated `check_win_condition` and `check_loss_condition` in `GameScene` to use an early return upon finding the first valid entity, rather than counting all entities and checking if the count is zero.

### 🎯 Why
In ECS loops that evaluate boolean satisfaction (like checking if any enemies remain, or if any player units remain), accumulating a full count forces the program to iterate through every single entity with that component. This takes O(N) time. By using an early return, the iteration stops immediately upon finding the first match, converting it to O(1) in the average case.

### 📊 Impact
Reduces iteration overhead in the `GameScene.update` loop, which calls these checks every single frame.

### 🔬 Measurement
All `pytest` tests pass successfully, confirming that the early return logic accurately reflects the original win/loss state without regressions.

---
*PR created automatically by Jules for task [4981099788444042273](https://jules.google.com/task/4981099788444042273) started by @tsainez*