### PR TITLE
🎨 Palette: Add rapid pagination to file dialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,7 @@
 ## 2026-05-24 - Consistent Helper Text Guidance
 **Learning:** Pygame menus lacking contextual "helper text" can leave users guessing about the exact nature of options (e.g., "Continue Campaign" vs "New Game"). Using a pattern established in the `SettingsScene`, adding descriptive text to the `MenuScene` significantly boosts discoverability and accessibility.
 **Action:** When creating or modifying full-screen menus, define a dictionary mapping options to descriptive helper text strings. Render the string corresponding to the currently selected option consistently at the bottom of the screen to guide user intent and improve the menu's overall UX.
+
+## 2024-06-16 - Rapid Pagination in Scrollable UI
+**Learning:** Keyboard accessibility and navigation speed in Pygame scrollable UI components (like FileDialog) are significantly improved by supporting rapid pagination.
+**Action:** Handle `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` key events to jump by the maximum visible items (e.g., `self._navigate(-self.max_visible_files)`).

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:

--- a/tests/unit/ui/test_file_dialog.py
+++ b/tests/unit/ui/test_file_dialog.py
@@ -160,3 +160,21 @@ class TestFileDialog:
         file_dialog.handle_event(event)
         assert file_dialog.hovered_element is None
         assert file_dialog.hovered_file_index is None
+
+    def test_keyboard_pagination(self, file_dialog):
+        # Setup files for pagination
+        file_dialog.files = [f"map{i}.json" for i in range(20)]
+        file_dialog.input_text = "map0.json"
+
+        event = MagicMock()
+        event.type = pygame.KEYDOWN
+
+        # Test Page Down
+        event.key = pygame.K_PAGEDOWN
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "map10.json"
+
+        # Test Page Up
+        event.key = pygame.K_PAGEUP
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "map0.json"


### PR DESCRIPTION
💡 **What**: Added rapid pagination support to the `FileDialog` component using `Page Up` and `Page Down` keys.
🎯 **Why**: To improve keyboard accessibility and navigation speed when browsing through long lists of files, making the UI more efficient and user-friendly.
📸 **Before/After**: N/A (Behavioral change, no visual layout differences).
♿ **Accessibility**: Significantly improves keyboard navigation by allowing rapid movement through scrollable lists without relying on a mouse or repeated single-step key presses.

---
*PR created automatically by Jules for task [15175843459231020617](https://jules.google.com/task/15175843459231020617) started by @tsainez*