### PR TITLE
🎨 Palette: Add rapid keyboard pagination to FileDialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,7 @@
 ## 2026-05-24 - Consistent Helper Text Guidance
 **Learning:** Pygame menus lacking contextual "helper text" can leave users guessing about the exact nature of options (e.g., "Continue Campaign" vs "New Game"). Using a pattern established in the `SettingsScene`, adding descriptive text to the `MenuScene` significantly boosts discoverability and accessibility.
 **Action:** When creating or modifying full-screen menus, define a dictionary mapping options to descriptive helper text strings. Render the string corresponding to the currently selected option consistently at the bottom of the screen to guide user intent and improve the menu's overall UX.
+
+## 2024-05-24 - Rapid Pagination in UI
+**Learning:** Implementing PageUp/PageDown keys for rapid pagination significantly improves keyboard accessibility and navigation speed in scrollable Pygame components.
+**Action:** Always handle K_PAGEUP and K_PAGEDOWN in Pygame UI lists.

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:

--- a/tests/unit/ui/test_file_dialog.py
+++ b/tests/unit/ui/test_file_dialog.py
@@ -160,3 +160,41 @@ class TestFileDialog:
         file_dialog.handle_event(event)
         assert file_dialog.hovered_element is None
         assert file_dialog.hovered_file_index is None
+
+    def test_keyboard_pagination(self, file_dialog):
+        # Add enough files to test pagination
+        file_dialog.files = [f"file{i}.txt" for i in range(25)]
+        file_dialog.input_text = "file0.txt"
+        file_dialog.max_visible_files = 10
+
+        event = MagicMock()
+        event.type = pygame.KEYDOWN
+
+        # Test Page Down
+        event.key = pygame.K_PAGEDOWN
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "file10.txt"
+
+        # Test Page Down again
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "file20.txt"
+
+        # Test Page Up
+        event.key = pygame.K_PAGEUP
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "file10.txt"
+
+        # Test Page Up to bounds
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "file0.txt"
+
+        # Test Page Up beyond bounds
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "file0.txt"
+
+        # Test Page Down beyond bounds
+        event.key = pygame.K_PAGEDOWN
+        file_dialog.handle_event(event)
+        file_dialog.handle_event(event)
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "file24.txt"


### PR DESCRIPTION
💡 **What**: Added `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` handlers to the `FileDialog` component to allow scrolling the list by a full page of items at a time (`self.max_visible_files`). Included comprehensive unit tests in `test_file_dialog.py`.
🎯 **Why**: Navigating large lists of maps or save files using only the Up/Down arrow keys is tedious and slow. Adding standard Page Up/Down keyboard shortcuts significantly improves the navigation speed and overall keyboard accessibility of the component.
📸 **Before/After**: Users can now instantly page through large directories rather than pressing 'Down' 10+ times.
♿ **Accessibility**: Enhances keyboard navigation speed, reducing repetitive strain and matching standard UI interaction patterns for scrollable lists.

---
*PR created automatically by Jules for task [7113360928053822194](https://jules.google.com/task/7113360928053822194) started by @tsainez*