### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API (Switching players)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -42,3 +42,7 @@
 **Vulnerability:** Not a direct vulnerability, but a testing failure related to TOCTOU prevention.
 **Learning:** When migrating from `json.load(f)` to `content = f.read(); json.loads(content)`, the mocked `open()` function must explicitly mock the `.read()` method. If left un-mocked, `.read()` returns a `MagicMock`, which causes `json.loads()` to throw a `TypeError: the JSON object must be str, bytes or bytearray`.
 **Prevention:** Always update associated unit tests to reflect the new `f.read()` behavior by explicitly setting `mock_file.read.return_value = "..."`.
+## 2026-06-18 - [Fix Authorization Bypass in Debug Cheats]
+**Vulnerability:** The "Switch Player" (TAB) cheat was accessible even when `config.DEBUG` was disabled, allowing players to bypass intended gameplay flow.
+**Learning:** All developer and debug features, such as cheat codes or side-switching functionalities in Pygame scenes, must be explicitly gated behind configuration flags (e.g., `config.DEBUG`). If multiple cheat keys are handled sequentially, ensure all of them fall inside the scope of the authorization check.
+**Prevention:** Group developer features under a single `if config.DEBUG:` block, and double-check indentation for all related conditionals.

--- a/command_line_conflict/scenes/game.py
+++ b/command_line_conflict/scenes/game.py
@@ -334,16 +334,15 @@ class GameScene:
                             status = "Enabled" if self.cheats["god_mode"] else "Disabled"
                             log.info(f"Cheat 'God Mode' toggled: {self.cheats['god_mode']}")
                             self.chat_system.add_message(f"Cheat: God Mode {status}", (255, 0, 255))
-
-                    if event.key == pygame.K_TAB:
-                        # Switch sides
-                        self.selection_system.clear_selection(self.game_state)
-                        if self.current_player_id == 1:
-                            self.current_player_id = 2
-                        else:
-                            self.current_player_id = 1
-                        log.info(f"Switched to player {self.current_player_id}")
-                        self.chat_system.add_message(f"Switched to player {self.current_player_id}", (255, 0, 255))
+                        elif event.key == pygame.K_TAB:
+                            # Switch sides
+                            self.selection_system.clear_selection(self.game_state)
+                            if self.current_player_id == 1:
+                                self.current_player_id = 2
+                            else:
+                                self.current_player_id = 1
+                            log.info(f"Switched to player {self.current_player_id}")
+                            self.chat_system.add_message(f"Switched to player {self.current_player_id}", (255, 0, 255))
 
                 if event.key == pygame.K_h:
                     # Hold Position


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The "Switch Player" (TAB) cheat was accessible even when `config.DEBUG` was disabled, allowing players to bypass intended gameplay flow.
🎯 Impact: Players could switch sides during a normal game, controlling the AI's units and seeing the map from the AI's perspective.
🔧 Fix: Indented the `TAB` key handling so it is properly gated under the existing `if config.DEBUG:` block.
✅ Verification: Ran the test suite to ensure the game works correctly.

---
*PR created automatically by Jules for task [13820453976861529327](https://jules.google.com/task/13820453976861529327) started by @tsainez*