### PR TITLE
⚡ Bolt: Early exit in win/loss conditions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2024-06-14 - [Optimize Distance Checks and Vector Math]
 **Learning:** In performance-critical vector math (like movement updates and fleeing checks calculated per-entity per-frame), calculating `math.sqrt()` is relatively expensive. Often we only need to know if the distance is below a threshold or non-zero. Additionally, dividing multiple coordinate deltas (`dx / dist`, `dy / dist`) introduces redundant division overhead.
 **Action:** Replace `math.sqrt()` with squared distance calculations (`dist_sq = dx * dx + dy * dy`) and compare against squared thresholds for early exits. When square roots are necessary, calculate them once and pre-calculate a multiplication ratio (`step_ratio = (speed * dt) / dist`) to apply to all coordinate deltas.
+## 2024-06-18 - [Optimize ECS Boolean Checks]
+**Learning:** Iterating over ECS entities to evaluate boolean satisfaction (like checking if any enemies are alive for a win/loss condition) by accumulating a total count causes unnecessary O(N) overhead per frame, especially when there are many entities.
+**Action:** Use an early return (`return False/True`) upon finding the first match to short-circuit the loop. This converts the O(N) operation to O(1) in the average case and improves frame time during the update loop.

--- a/command_line_conflict/scenes/game.py
+++ b/command_line_conflict/scenes/game.py
@@ -577,7 +577,6 @@ class GameScene:
         Returns:
             True if the win condition is met, False otherwise.
         """
-        enemy_count = 0
         for entity_id in self.game_state.get_entities_with_component(Player):
             components = self.game_state.entities.get(entity_id)
             if not components:
@@ -588,25 +587,23 @@ class GameScene:
                 if self.has_player_2_opponent and player.player_id == config.NEUTRAL_PLAYER_ID:
                     continue
                 if Health in components:
-                    enemy_count += 1
+                    return False
 
-        if enemy_count == 0:
-            log.info("Victory! Mission Complete.")
-            self.game.steam.unlock_achievement("VICTORY")
-            # Trigger victory sound (note: scene switch might cut it off if SoundSystem isn't persistent or updated)
-            # Since SoundSystem is part of GameScene, and we switch scene, we should ideally play it in the new scene
-            # or ensure the sound continues. For now, we emit the event.
-            # But wait, if we switch immediately, update won't process events.
-            # However, GameScene.update processes systems then checks win.
-            # So the event might be lost if we don't process it.
-            # Actually, SoundSystem.update is called BEFORE check_win_condition in update().
-            # So if we add event here, it won't be processed until NEXT frame's SoundSystem.update.
-            # But next frame we are in VictoryScene.
-            # So we should play it directly via self.sound_system.play_sound("victory") to ensure it starts.
-            self.sound_system.play_sound("victory")
-            self.campaign_manager.complete_mission(self.current_mission_id)
-            return True
-        return False
+        log.info("Victory! Mission Complete.")
+        self.game.steam.unlock_achievement("VICTORY")
+        # Trigger victory sound (note: scene switch might cut it off if SoundSystem isn't persistent or updated)
+        # Since SoundSystem is part of GameScene, and we switch scene, we should ideally play it in the new scene
+        # or ensure the sound continues. For now, we emit the event.
+        # But wait, if we switch immediately, update won't process events.
+        # However, GameScene.update processes systems then checks win.
+        # So the event might be lost if we don't process it.
+        # Actually, SoundSystem.update is called BEFORE check_win_condition in update().
+        # So if we add event here, it won't be processed until NEXT frame's SoundSystem.update.
+        # But next frame we are in VictoryScene.
+        # So we should play it directly via self.sound_system.play_sound("victory") to ensure it starts.
+        self.sound_system.play_sound("victory")
+        self.campaign_manager.complete_mission(self.current_mission_id)
+        return True
 
     def check_loss_condition(self) -> bool:
         """Checks if the player has lost the level.
@@ -614,7 +611,6 @@ class GameScene:
         Returns:
             True if the loss condition is met, False otherwise.
         """
-        player_entity_count = 0
         for entity_id in self.game_state.get_entities_with_component(Player):
             components = self.game_state.entities.get(entity_id)
             if not components:
@@ -624,14 +620,12 @@ class GameScene:
             if player and player.is_human:
                 # Check for any player-controlled entity (unit or building)
                 if Health in components:
-                    player_entity_count += 1
+                    return False
 
-        if player_entity_count == 0:
-            log.info("Defeat! Mission Failed.")
-            self.game.steam.unlock_achievement("DEFEAT")
-            self.sound_system.play_sound("defeat")
-            return True
-        return False
+        log.info("Defeat! Mission Failed.")
+        self.game.steam.unlock_achievement("DEFEAT")
+        self.sound_system.play_sound("defeat")
+        return True
 
     def draw(self, screen):
         """Draws the entire game scene.


### PR DESCRIPTION
- **💡 What**: Updated `check_win_condition` and `check_loss_condition` in `GameScene` to use early returns (`return False`) instead of accumulating counts over ECS component iterations.
- **🎯 Why**: Iterating over all entities and counting them introduces O(N) overhead per frame when checking for win/loss conditions. Using an early return reduces this overhead and prevents unneeded operations, as finding just one matching entity is sufficient to disprove the win or loss condition.
- **📊 Impact**: Reduces loop duration from O(N) to O(1) on average.
- **🔬 Measurement**: Verified via test suite (`pytest --no-cov`) ensuring no functionality or behavior is broken.

---
*PR created automatically by Jules for task [7939202603924781316](https://jules.google.com/task/7939202603924781316) started by @tsainez*