### PR TITLE
🎨 Palette: Add rapid pagination to FileDialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,6 @@
 ## 2026-05-24 - Consistent Helper Text Guidance
 **Learning:** Pygame menus lacking contextual "helper text" can leave users guessing about the exact nature of options (e.g., "Continue Campaign" vs "New Game"). Using a pattern established in the `SettingsScene`, adding descriptive text to the `MenuScene` significantly boosts discoverability and accessibility.
 **Action:** When creating or modifying full-screen menus, define a dictionary mapping options to descriptive helper text strings. Render the string corresponding to the currently selected option consistently at the bottom of the screen to guide user intent and improve the menu's overall UX.
+## 2024-06-18 - Rapid Pagination in Scrollable Lists
+**Learning:** Keyboard navigation in scrollable Pygame UI components (like `FileDialog`) can feel slow when users must press up/down for every single item, degrading accessibility and user experience.
+**Action:** Implement rapid pagination support by handling `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` to jump by the maximum visible items (`max_visible_files`), significantly speeding up navigation.

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:

--- a/tests/unit/ui/test_file_dialog.py
+++ b/tests/unit/ui/test_file_dialog.py
@@ -114,6 +114,24 @@ class TestFileDialog:
         file_dialog.handle_event(event)
         assert file_dialog.input_text == ""
 
+    def test_pagination_keys(self, file_dialog):
+        # Setup files for pagination
+        file_dialog.files = [f"map{i}.json" for i in range(20)]
+        file_dialog.input_text = "map0.json"
+
+        event = MagicMock()
+        event.type = pygame.KEYDOWN
+
+        # Test Page Down
+        event.key = pygame.K_PAGEDOWN
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == f"map{file_dialog.max_visible_files}.json"
+
+        # Test Page Up
+        event.key = pygame.K_PAGEUP
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "map0.json"
+
     def test_escape_closes(self, file_dialog):
         event = MagicMock()
         event.type = pygame.KEYDOWN


### PR DESCRIPTION
💡 **What**: Added rapid pagination to the `FileDialog` component using the Page Up and Page Down keys.
🎯 **Why**: Scrolling through a long list of files one by one using the arrow keys is slow and frustrating. Page Up/Down allows jumping by the maximum number of visible items, drastically speeding up navigation.
📸 **Before/After**: No visual changes, but behavioral speed is significantly improved.
♿ **Accessibility**: Improves keyboard navigation efficiency for users relying heavily on keyboard controls, reducing repetitive keystrokes.

---
*PR created automatically by Jules for task [7782835233086269652](https://jules.google.com/task/7782835233086269652) started by @tsainez*