### PR TITLE
🎨 Palette: [keyboard accessibility] Add PageUp/PageDown rapid pagination to FileDialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,7 @@
 ## 2026-05-24 - Consistent Helper Text Guidance
 **Learning:** Pygame menus lacking contextual "helper text" can leave users guessing about the exact nature of options (e.g., "Continue Campaign" vs "New Game"). Using a pattern established in the `SettingsScene`, adding descriptive text to the `MenuScene` significantly boosts discoverability and accessibility.
 **Action:** When creating or modifying full-screen menus, define a dictionary mapping options to descriptive helper text strings. Render the string corresponding to the currently selected option consistently at the bottom of the screen to guide user intent and improve the menu's overall UX.
+
+## 2024-05-24 - Pagination in Scrollable UI
+**Learning:** Scrollable UI components (like `FileDialog`) can be tedious to navigate with just arrow keys, especially with long lists. Keyboard users expect rapid navigation shortcuts.
+**Action:** Implement rapid pagination support by handling `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` key events to jump by the maximum visible items in scrollable lists.

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:

--- a/tests/unit/ui/test_file_dialog.py
+++ b/tests/unit/ui/test_file_dialog.py
@@ -122,6 +122,22 @@ class TestFileDialog:
         file_dialog.handle_event(event)
         assert file_dialog.active is False
 
+    def test_pagination(self, file_dialog):
+        file_dialog.files = ["map1.json", "map2.json", "map3.json", "map4.json"]
+        file_dialog.max_visible_files = 2
+        file_dialog.input_text = "map1.json"
+
+        event = MagicMock()
+        event.type = pygame.KEYDOWN
+
+        event.key = pygame.K_PAGEDOWN
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "map3.json"
+
+        event.key = pygame.K_PAGEUP
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "map1.json"
+
     def test_hover_states(self, file_dialog):
         # Move over close button
         event = MagicMock()


### PR DESCRIPTION
💡 **What:** Added `Page Up` and `Page Down` keyboard shortcuts to navigate by the maximum visible items in the FileDialog.
🎯 **Why:** To improve keyboard accessibility and allow faster, less tedious navigation through long lists of files, reducing reliance on single arrow key presses or the mouse scroll wheel.
📸 **Before/After:** No visual change.
♿ **Accessibility:** Users relying on keyboard navigation can now rapidly skip through overflow content in scrollable UI lists using standard `PageUp`/`PageDown` pagination conventions.

---
*PR created automatically by Jules for task [16433475045134450250](https://jules.google.com/task/16433475045134450250) started by @tsainez*