### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix side-switching authorization bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -42,3 +42,8 @@
 **Vulnerability:** Not a direct vulnerability, but a testing failure related to TOCTOU prevention.
 **Learning:** When migrating from `json.load(f)` to `content = f.read(); json.loads(content)`, the mocked `open()` function must explicitly mock the `.read()` method. If left un-mocked, `.read()` returns a `MagicMock`, which causes `json.loads()` to throw a `TypeError: the JSON object must be str, bytes or bytearray`.
 **Prevention:** Always update associated unit tests to reflect the new `f.read()` behavior by explicitly setting `mock_file.read.return_value = "..."`.
+
+## 2026-06-22 - Authorization Bypass via Developer Keybinds
+**Vulnerability:** A "switch sides" developer cheat (TAB key) was exposed in production builds because it lacked the `if config.DEBUG:` guard present on other debug commands.
+**Learning:** Developer and debug keybinds placed in close proximity to properly gated logic can accidentally slip out of the conditionally gated scope, resulting in authorization bypasses.
+**Prevention:** Ensure that all developer features, especially those that manipulate authentication/authorization states like player identity, are explicitly and strictly scoped under the application's debug configuration flags.

--- a/command_line_conflict/scenes/game.py
+++ b/command_line_conflict/scenes/game.py
@@ -334,16 +334,15 @@ class GameScene:
                             status = "Enabled" if self.cheats["god_mode"] else "Disabled"
                             log.info(f"Cheat 'God Mode' toggled: {self.cheats['god_mode']}")
                             self.chat_system.add_message(f"Cheat: God Mode {status}", (255, 0, 255))
-
-                    if event.key == pygame.K_TAB:
-                        # Switch sides
-                        self.selection_system.clear_selection(self.game_state)
-                        if self.current_player_id == 1:
-                            self.current_player_id = 2
-                        else:
-                            self.current_player_id = 1
-                        log.info(f"Switched to player {self.current_player_id}")
-                        self.chat_system.add_message(f"Switched to player {self.current_player_id}", (255, 0, 255))
+                        elif event.key == pygame.K_TAB:
+                            # Switch sides
+                            self.selection_system.clear_selection(self.game_state)
+                            if self.current_player_id == 1:
+                                self.current_player_id = 2
+                            else:
+                                self.current_player_id = 1
+                            log.info(f"Switched to player {self.current_player_id}")
+                            self.chat_system.add_message(f"Switched to player {self.current_player_id}", (255, 0, 255))
 
                 if event.key == pygame.K_h:
                     # Hold Position


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A "switch sides" developer cheat (TAB key) was exposed in production builds because it lacked the `if config.DEBUG:` guard present on other debug commands.
🎯 Impact: Players could bypass authorization by pressing the TAB key during normal gameplay, immediately taking control of the enemy player's units.
🔧 Fix: Nested the `elif event.key == pygame.K_TAB:` check under the pre-existing `if config.DEBUG:` block in `command_line_conflict/scenes/game.py`.
✅ Verification: Ran `source .venv/bin/activate && python3 -m pytest tests/ --no-cov`. Ensured all tests, including existing mock tests that verify cheat functionality under `DEBUG = True`, continue to pass, proving the logic works correctly inside the gated scope.

---
*PR created automatically by Jules for task [7855019960279215176](https://jules.google.com/task/7855019960279215176) started by @tsainez*