### PR TITLE
🎨 Palette: [UX improvement] Add keyboard pagination to FileDialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,7 @@
 ## 2026-05-24 - Consistent Helper Text Guidance
 **Learning:** Pygame menus lacking contextual "helper text" can leave users guessing about the exact nature of options (e.g., "Continue Campaign" vs "New Game"). Using a pattern established in the `SettingsScene`, adding descriptive text to the `MenuScene` significantly boosts discoverability and accessibility.
 **Action:** When creating or modifying full-screen menus, define a dictionary mapping options to descriptive helper text strings. Render the string corresponding to the currently selected option consistently at the bottom of the screen to guide user intent and improve the menu's overall UX.
+
+## 2024-06-22 - Keyboard Pagination in Scrollable Lists
+**Learning:** To improve keyboard accessibility and navigation speed in Pygame scrollable UI components (such as `FileDialog`), implement rapid pagination support by handling `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` key events to jump by the maximum visible items (e.g., `self._navigate(-self.max_visible_files)`).
+**Action:** Always map Page Up / Page Down keys to `self._navigate(-max_visible)` and `self._navigate(max_visible)` in custom scrollable list components to facilitate fast keyboard navigation.

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:

--- a/tests/unit/ui/test_file_dialog.py
+++ b/tests/unit/ui/test_file_dialog.py
@@ -160,3 +160,19 @@ class TestFileDialog:
         file_dialog.handle_event(event)
         assert file_dialog.hovered_element is None
         assert file_dialog.hovered_file_index is None
+
+    def test_keyboard_pagination(self, file_dialog):
+        # Setup many files
+        file_dialog.files = [f"file{i}.json" for i in range(20)]
+        file_dialog.input_text = "file0.json"
+        file_dialog.scroll_offset = 0
+
+        event = MagicMock()
+        event.type = pygame.KEYDOWN
+        event.key = pygame.K_PAGEDOWN
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "file10.json"
+
+        event.key = pygame.K_PAGEUP
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == "file0.json"


### PR DESCRIPTION
💡 What: Added Page Up and Page Down keyboard navigation to the FileDialog component.
🎯 Why: To improve keyboard accessibility and navigation speed for large file lists. Before this change, users had to hold the Up/Down arrows to scroll through long lists of saves or maps.
📸 Before/After: Visuals are unchanged, but keyboard interaction is significantly faster.
♿ Accessibility: Rapid navigation is critical for keyboard-only users navigating large lists.

---
*PR created automatically by Jules for task [14283114124100262463](https://jules.google.com/task/14283114124100262463) started by @tsainez*