### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in game scene

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -42,3 +42,7 @@
 **Vulnerability:** Not a direct vulnerability, but a testing failure related to TOCTOU prevention.
 **Learning:** When migrating from `json.load(f)` to `content = f.read(); json.loads(content)`, the mocked `open()` function must explicitly mock the `.read()` method. If left un-mocked, `.read()` returns a `MagicMock`, which causes `json.loads()` to throw a `TypeError: the JSON object must be str, bytes or bytearray`.
 **Prevention:** Always update associated unit tests to reflect the new `f.read()` behavior by explicitly setting `mock_file.read.return_value = "..."`.
+## 2024-05-15 - [Authorization Bypass via Developer Keybinds]
+**Vulnerability:** The player side-switching functionality (K_TAB) was accessible outside of the `config.DEBUG` gating in `command_line_conflict/scenes/game.py`.
+**Learning:** Developer keybinds that alter game state or provide unauthorized features must be explicitly nested within debug configuration checks, as placement in the general event loop exposes them to all users.
+**Prevention:** Always verify that every cheat code or developer-only input event handler is strictly contained within an active `if config.DEBUG:` (or similar environment flag) block.

--- a/command_line_conflict/scenes/game.py
+++ b/command_line_conflict/scenes/game.py
@@ -334,16 +334,15 @@ class GameScene:
                             status = "Enabled" if self.cheats["god_mode"] else "Disabled"
                             log.info(f"Cheat 'God Mode' toggled: {self.cheats['god_mode']}")
                             self.chat_system.add_message(f"Cheat: God Mode {status}", (255, 0, 255))
-
-                    if event.key == pygame.K_TAB:
-                        # Switch sides
-                        self.selection_system.clear_selection(self.game_state)
-                        if self.current_player_id == 1:
-                            self.current_player_id = 2
-                        else:
-                            self.current_player_id = 1
-                        log.info(f"Switched to player {self.current_player_id}")
-                        self.chat_system.add_message(f"Switched to player {self.current_player_id}", (255, 0, 255))
+                        elif event.key == pygame.K_TAB:
+                            # Switch sides
+                            self.selection_system.clear_selection(self.game_state)
+                            if self.current_player_id == 1:
+                                self.current_player_id = 2
+                            else:
+                                self.current_player_id = 1
+                            log.info(f"Switched to player {self.current_player_id}")
+                            self.chat_system.add_message(f"Switched to player {self.current_player_id}", (255, 0, 255))
 
                 if event.key == pygame.K_h:
                     # Hold Position


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The player side-switching functionality (K_TAB) was accessible outside of the `config.DEBUG` gating in `command_line_conflict/scenes/game.py`.
🎯 Impact: Any player could arbitrarily switch the side they were controlling during active gameplay in production builds, breaking game balance and state.
🔧 Fix: Indented the `event.key == pygame.K_TAB` block into the preceding `if config.DEBUG:` section by converting it to an `elif`.
✅ Verification: Ran `pytest tests/ --no-cov` locally to ensure no logic regressions occurred and the change complies with the application's flow.

---
*PR created automatically by Jules for task [11279366059402811394](https://jules.google.com/task/11279366059402811394) started by @tsainez*