### PR TITLE
🎨 Palette: [UX improvement] Add rapid pagination to FileDialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,6 @@
 ## 2026-05-24 - Consistent Helper Text Guidance
 **Learning:** Pygame menus lacking contextual "helper text" can leave users guessing about the exact nature of options (e.g., "Continue Campaign" vs "New Game"). Using a pattern established in the `SettingsScene`, adding descriptive text to the `MenuScene` significantly boosts discoverability and accessibility.
 **Action:** When creating or modifying full-screen menus, define a dictionary mapping options to descriptive helper text strings. Render the string corresponding to the currently selected option consistently at the bottom of the screen to guide user intent and improve the menu's overall UX.
+## 2024-06-23 - Rapid Pagination in Scrollable UI
+**Learning:** Pygame scrollable list components without native OS scrollbars can be tedious to navigate with just arrow keys, especially for long lists like file dialogs.
+**Action:** Implement `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` support using the internal navigation delta logic scaled to `max_visible_items` to significantly improve keyboard accessibility and navigation speed.

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:
@@ -305,7 +309,7 @@ class FileDialog:
         self.screen.set_clip(None)
 
         # Helper hint beneath the input for quick keyboard guidance.
-        hint_text = "Enter to confirm, Esc to cancel, scroll to browse"
+        hint_text = "Enter to confirm, Esc to cancel, scroll/PgUp/PgDn to browse"
         hint_surf = self.font.render(hint_text, True, (170, 170, 170))
         self.screen.blit(hint_surf, (self.input_rect.x, self.input_rect.y + 32))
 


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add rapid pagination to FileDialog

💡 What:
Added `PageUp` and `PageDown` keyboard support to the `FileDialog` component for rapid navigation through long file lists, and updated the helper text to make the shortcuts discoverable.

🎯 Why:
Navigating through long lists (like campaign directories or large map sets) using only the up and down arrow keys can be tedious. Adding page jump functionality significantly improves navigation speed.

📸 Before/After:
Before: `Enter to confirm, Esc to cancel, scroll to browse`
After: `Enter to confirm, Esc to cancel, scroll/PgUp/PgDn to browse`

♿ Accessibility:
Significantly improves keyboard accessibility for users who cannot or prefer not to use a mouse to interact with the scrollable list.

Also recorded the learning regarding Pygame pagination in `.jules/palette.md`.

---
*PR created automatically by Jules for task [15633380067134059657](https://jules.google.com/task/15633380067134059657) started by @tsainez*