### PR TITLE
🛡️ Sentinel: [HIGH] Fix side-switching authorization bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -42,3 +42,7 @@
 **Vulnerability:** Not a direct vulnerability, but a testing failure related to TOCTOU prevention.
 **Learning:** When migrating from `json.load(f)` to `content = f.read(); json.loads(content)`, the mocked `open()` function must explicitly mock the `.read()` method. If left un-mocked, `.read()` returns a `MagicMock`, which causes `json.loads()` to throw a `TypeError: the JSON object must be str, bytes or bytearray`.
 **Prevention:** Always update associated unit tests to reflect the new `f.read()` behavior by explicitly setting `mock_file.read.return_value = "..."`.
+## 2024-06-05 - [Side-Switching Authorization Bypass]
+**Vulnerability:** A developer cheat to switch player sides (TAB key) was left outside the `config.DEBUG` check, allowing any player in production to take over the opposing side.
+**Learning:** Even features intended solely for development testing must be explicitly gated by environment flags to prevent authorization bypasses.
+**Prevention:** Strictly enclose all developer shortcuts, cheats, and debug features within `if config.DEBUG:` blocks to prevent production exploitation.

--- a/command_line_conflict/scenes/game.py
+++ b/command_line_conflict/scenes/game.py
@@ -335,15 +335,15 @@ class GameScene:
                             log.info(f"Cheat 'God Mode' toggled: {self.cheats['god_mode']}")
                             self.chat_system.add_message(f"Cheat: God Mode {status}", (255, 0, 255))
 
-                    if event.key == pygame.K_TAB:
-                        # Switch sides
-                        self.selection_system.clear_selection(self.game_state)
-                        if self.current_player_id == 1:
-                            self.current_player_id = 2
-                        else:
-                            self.current_player_id = 1
-                        log.info(f"Switched to player {self.current_player_id}")
-                        self.chat_system.add_message(f"Switched to player {self.current_player_id}", (255, 0, 255))
+                        elif event.key == pygame.K_TAB:
+                            # Switch sides
+                            self.selection_system.clear_selection(self.game_state)
+                            if self.current_player_id == 1:
+                                self.current_player_id = 2
+                            else:
+                                self.current_player_id = 1
+                            log.info(f"Switched to player {self.current_player_id}")
+                            self.chat_system.add_message(f"Switched to player {self.current_player_id}", (255, 0, 255))
 
                 if event.key == pygame.K_h:
                     # Hold Position


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: A developer cheat to switch player sides (using the TAB key) was left outside the `config.DEBUG` check. This allowed any player in production to take over the opposing side.
🎯 **Impact**: Authorization bypass, allowing players to manipulate the opposing team and break the core mechanics of the game.
🔧 **Fix**: Moved the `if event.key == pygame.K_TAB:` block under the preceding `if config.DEBUG:` block in `command_line_conflict/scenes/game.py`, ensuring this developer-only feature is restricted in production.
✅ **Verification**: Code formatted with `black` and full test suite (`pytest`) successfully passed locally.

---
*PR created automatically by Jules for task [15387507236722999226](https://jules.google.com/task/15387507236722999226) started by @tsainez*