### PR TITLE
🎨 Palette: Add rapid keyboard pagination to file dialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,6 @@
 ## 2026-05-24 - Consistent Helper Text Guidance
 **Learning:** Pygame menus lacking contextual "helper text" can leave users guessing about the exact nature of options (e.g., "Continue Campaign" vs "New Game"). Using a pattern established in the `SettingsScene`, adding descriptive text to the `MenuScene` significantly boosts discoverability and accessibility.
 **Action:** When creating or modifying full-screen menus, define a dictionary mapping options to descriptive helper text strings. Render the string corresponding to the currently selected option consistently at the bottom of the screen to guide user intent and improve the menu's overall UX.
+## 2024-06-25 - Implement rapid pagination in FileDialog
+**Learning:** For scrollable UI components like `FileDialog` in Pygame, relying solely on UP/DOWN arrow keys makes navigating long lists tedious. Users expect rapid pagination support using PageUp and PageDown keys for better keyboard accessibility and faster navigation.
+**Action:** Implement `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` handlers using the internal `_navigate()` method to jump by `max_visible_items` in all custom Pygame scrollable components.

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:

--- a/tests/unit/ui/test_file_dialog.py
+++ b/tests/unit/ui/test_file_dialog.py
@@ -114,6 +114,23 @@ class TestFileDialog:
         file_dialog.handle_event(event)
         assert file_dialog.input_text == ""
 
+    def test_pagination(self, file_dialog):
+        # Setup files so pagination has effect
+        file_dialog.files = [f"file_{i}.txt" for i in range(20)]
+        file_dialog.input_text = file_dialog.files[0]
+        file_dialog.max_visible_files = 10
+
+        event = MagicMock()
+        event.type = pygame.KEYDOWN
+
+        event.key = pygame.K_PAGEDOWN
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == file_dialog.files[10]
+
+        event.key = pygame.K_PAGEUP
+        file_dialog.handle_event(event)
+        assert file_dialog.input_text == file_dialog.files[0]
+
     def test_escape_closes(self, file_dialog):
         event = MagicMock()
         event.type = pygame.KEYDOWN


### PR DESCRIPTION
💡 What: Added PageUp and PageDown keyboard handlers to the `FileDialog` component to rapidly scroll through file lists.
🎯 Why: Relying solely on UP/DOWN arrow keys makes navigating long lists tedious. Users expect rapid pagination support for better keyboard accessibility and faster navigation.
📸 Before/After: Visuals unchanged, but pressing PageUp/PageDown now skips exactly `max_visible_files` items at a time.
♿ Accessibility: Dramatically improves keyboard navigation for users relying on keyboard input instead of a mouse scroll wheel.

---
*PR created automatically by Jules for task [1993226558239736749](https://jules.google.com/task/1993226558239736749) started by @tsainez*