### PR TITLE
🎨 Palette: [UX improvement] Add keyboard pagination support to FileDialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,7 @@
 ## 2026-05-24 - Consistent Helper Text Guidance
 **Learning:** Pygame menus lacking contextual "helper text" can leave users guessing about the exact nature of options (e.g., "Continue Campaign" vs "New Game"). Using a pattern established in the `SettingsScene`, adding descriptive text to the `MenuScene` significantly boosts discoverability and accessibility.
 **Action:** When creating or modifying full-screen menus, define a dictionary mapping options to descriptive helper text strings. Render the string corresponding to the currently selected option consistently at the bottom of the screen to guide user intent and improve the menu's overall UX.
+
+## 2024-05-25 - Rapid Keyboard Navigation
+**Learning:** Pygame scrollable lists without rapid keyboard navigation (PageUp/PageDown) make finding files in large directories tedious and accessible-unfriendly compared to standard OS dialogs.
+**Action:** In custom scrollable UI components, always support `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` keys to jump by the maximum visible items (e.g., `self.max_visible_files`) using internal navigation methods.

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:

--- a/tests/unit/ui/test_file_dialog.py
+++ b/tests/unit/ui/test_file_dialog.py
@@ -160,3 +160,18 @@ class TestFileDialog:
         file_dialog.handle_event(event)
         assert file_dialog.hovered_element is None
         assert file_dialog.hovered_file_index is None
+
+    def test_pagination_keys(self, file_dialog):
+        event = MagicMock()
+        event.type = pygame.KEYDOWN
+
+        # Mock _navigate
+        file_dialog._navigate = MagicMock()
+
+        event.key = pygame.K_PAGEDOWN
+        file_dialog.handle_event(event)
+        file_dialog._navigate.assert_called_with(file_dialog.max_visible_files)
+
+        event.key = pygame.K_PAGEUP
+        file_dialog.handle_event(event)
+        file_dialog._navigate.assert_called_with(-file_dialog.max_visible_files)


### PR DESCRIPTION
💡 What: Added support for `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` keys to the `FileDialog` component to allow rapid jumping through large scrollable lists.
🎯 Why: Pygame scrollable lists without rapid keyboard navigation make finding files in large directories tedious. By jumping `max_visible_files` items per keystroke, users can navigate large map lists effortlessly compared to single arrow key presses or mouse scrolling.
📸 Before/After: Before, pressing Page Up/Down did nothing. Now, it correctly advances or rewinds the cursor by a full page of visible items.
♿ Accessibility: significantly reduces the keystrokes needed for keyboard-only users to navigate the interface.

---
*PR created automatically by Jules for task [7175208696287031527](https://jules.google.com/task/7175208696287031527) started by @tsainez*