### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix side-switching authorization bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -42,3 +42,7 @@
 **Vulnerability:** Not a direct vulnerability, but a testing failure related to TOCTOU prevention.
 **Learning:** When migrating from `json.load(f)` to `content = f.read(); json.loads(content)`, the mocked `open()` function must explicitly mock the `.read()` method. If left un-mocked, `.read()` returns a `MagicMock`, which causes `json.loads()` to throw a `TypeError: the JSON object must be str, bytes or bytearray`.
 **Prevention:** Always update associated unit tests to reflect the new `f.read()` behavior by explicitly setting `mock_file.read.return_value = "..."`.
+## 2026-06-27 - [Authorization Bypass via Developer Feature]
+**Vulnerability:** The developer side-switching feature (`pygame.K_TAB`) in GameScene was not gated by the DEBUG configuration flag, allowing any player in a production build to switch control to the enemy side, bypassing authorization.
+**Learning:** All developer and debug features, including those that manipulate game state or switch sides, must be explicitly gated behind configuration flags (e.g., `config.DEBUG`) to prevent unauthorized feature access in production builds. Improper indentation of such features can lead to severe logic and authorization flaws.
+**Prevention:** Always verify the indentation level of debug features to ensure they fall correctly under the configuration flag check.

--- a/command_line_conflict/scenes/game.py
+++ b/command_line_conflict/scenes/game.py
@@ -335,15 +335,15 @@ class GameScene:
                             log.info(f"Cheat 'God Mode' toggled: {self.cheats['god_mode']}")
                             self.chat_system.add_message(f"Cheat: God Mode {status}", (255, 0, 255))
 
-                    if event.key == pygame.K_TAB:
-                        # Switch sides
-                        self.selection_system.clear_selection(self.game_state)
-                        if self.current_player_id == 1:
-                            self.current_player_id = 2
-                        else:
-                            self.current_player_id = 1
-                        log.info(f"Switched to player {self.current_player_id}")
-                        self.chat_system.add_message(f"Switched to player {self.current_player_id}", (255, 0, 255))
+                        elif event.key == pygame.K_TAB:
+                            # Switch sides
+                            self.selection_system.clear_selection(self.game_state)
+                            if self.current_player_id == 1:
+                                self.current_player_id = 2
+                            else:
+                                self.current_player_id = 1
+                            log.info(f"Switched to player {self.current_player_id}")
+                            self.chat_system.add_message(f"Switched to player {self.current_player_id}", (255, 0, 255))
 
                 if event.key == pygame.K_h:
                     # Hold Position


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The developer side-switching feature (`pygame.K_TAB`) in GameScene was not gated by the DEBUG configuration flag due to improper indentation, allowing any player in a production build to switch control to the enemy side, bypassing authorization.
🎯 Impact: Players could switch sides during a multiplayer or singleplayer game without having developer permissions or cheat mode enabled, breaking core game logic and authorization.
🔧 Fix: Gated the `pygame.K_TAB` event handler correctly within the existing `if config.DEBUG:` block by adjusting the indentation and changing `if` to `elif`. Also recorded the learning in `.jules/sentinel.md`.
✅ Verification: Ran the full test suite with `python3 -m pytest tests/ --no-cov` to ensure no regressions were introduced. Formatted the codebase with `black`.

---
*PR created automatically by Jules for task [6858118214840591](https://jules.google.com/task/6858118214840591) started by @tsainez*