### PR TITLE
🎨 Palette: [UX improvement] Add keyboard pagination support to FileDialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,7 @@
 ## 2026-05-24 - Consistent Helper Text Guidance
 **Learning:** Pygame menus lacking contextual "helper text" can leave users guessing about the exact nature of options (e.g., "Continue Campaign" vs "New Game"). Using a pattern established in the `SettingsScene`, adding descriptive text to the `MenuScene` significantly boosts discoverability and accessibility.
 **Action:** When creating or modifying full-screen menus, define a dictionary mapping options to descriptive helper text strings. Render the string corresponding to the currently selected option consistently at the bottom of the screen to guide user intent and improve the menu's overall UX.
+
+## 2024-05-25 - Rapid Pagination in Scrollable Lists
+**Learning:** Scrolling through long lists of files in `FileDialog` using arrow keys one-by-one is tedious. Adding rapid pagination support (`pygame.K_PAGEUP` and `pygame.K_PAGEDOWN`) significantly improves keyboard accessibility and navigation speed in Pygame scrollable UI components.
+**Action:** When implementing scrollable lists or menus in Pygame UI components, ensure that keyboard shortcuts for jumping by the maximum visible items (e.g., handling `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` to navigate `+/- self.max_visible_files`) are included to provide a faster and more accessible keyboard navigation experience.

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -130,6 +130,10 @@ class FileDialog:
                 self._navigate(-1)
             elif event.key == pygame.K_DOWN:
                 self._navigate(1)
+            elif event.key == pygame.K_PAGEUP:
+                self._navigate(-self.max_visible_files)
+            elif event.key == pygame.K_PAGEDOWN:
+                self._navigate(self.max_visible_files)
             elif event.key == pygame.K_BACKSPACE:
                 self.input_text = self.input_text[:-1]
             else:


### PR DESCRIPTION
💡 What: Added support for `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` keys in the `FileDialog` component to allow jumping up and down the file list by the maximum number of visible files (`self.max_visible_files`).

🎯 Why: When navigating directories with long lists of files, scrolling one-by-one using the up/down arrow keys is tedious and slow. Adding rapid pagination improves navigation efficiency.

📸 Before/After: 
- Before: Users could only scroll file lists by single items using the UP/DOWN arrows or mouse wheel.
- After: Users can now press PAGE UP or PAGE DOWN to instantly jump by a full page of files, dramatically speeding up navigation in large directories.

♿ Accessibility: Significantly improves keyboard accessibility by providing a faster, standard navigation paradigm for scrollable lists, reducing the number of keypresses required for users who rely solely on keyboards.

---
*PR created automatically by Jules for task [2197002195815810004](https://jules.google.com/task/2197002195815810004) started by @tsainez*