### PR TITLE
🛡️ Sentinel: [HIGH] Fix side-switching authorization bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -42,3 +42,7 @@
 **Vulnerability:** Not a direct vulnerability, but a testing failure related to TOCTOU prevention.
 **Learning:** When migrating from `json.load(f)` to `content = f.read(); json.loads(content)`, the mocked `open()` function must explicitly mock the `.read()` method. If left un-mocked, `.read()` returns a `MagicMock`, which causes `json.loads()` to throw a `TypeError: the JSON object must be str, bytes or bytearray`.
 **Prevention:** Always update associated unit tests to reflect the new `f.read()` behavior by explicitly setting `mock_file.read.return_value = "..."`.
+## 2024-06-28 - [Side-Switching Authorization Bypass in GameScene]
+**Vulnerability:** The developer feature to switch sides (pressing TAB) was not gated by `config.DEBUG`. This allowed an attacker/player to switch to the opponent's side and issue commands, effectively bypassing authorization checks.
+**Learning:** Even features that seem like simple debugging tools can have severe security implications (like privilege escalation or auth bypass) if exposed in production.
+**Prevention:** All debug and testing features that modify state or switch roles must strictly check `config.DEBUG` or a similar configuration flag before executing.

--- a/command_line_conflict/scenes/game.py
+++ b/command_line_conflict/scenes/game.py
@@ -335,7 +335,7 @@ class GameScene:
                             log.info(f"Cheat 'God Mode' toggled: {self.cheats['god_mode']}")
                             self.chat_system.add_message(f"Cheat: God Mode {status}", (255, 0, 255))
 
-                    if event.key == pygame.K_TAB:
+                    if event.key == pygame.K_TAB and config.DEBUG:
                         # Switch sides
                         self.selection_system.clear_selection(self.game_state)
                         if self.current_player_id == 1:


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The developer feature to switch sides (pressing `TAB`) in `GameScene` was not gated by the `config.DEBUG` configuration flag.
🎯 **Impact**: An attacker or regular player could press `TAB` during normal gameplay to switch to the opponent's side. This allows them to issue commands to enemy units, effectively bypassing all authorization and game logic, leading to immediate cheating and gameplay disruption.
🔧 **Fix**: Modified the `event.key == pygame.K_TAB` check in `command_line_conflict/scenes/game.py` to also require `config.DEBUG` to be True.
✅ **Verification**: Ran the test suite `pytest --no-cov` to ensure no regressions. Verified that `TAB` only triggers a side switch when `config.DEBUG` is active.

---
*PR created automatically by Jules for task [11694763306698048340](https://jules.google.com/task/11694763306698048340) started by @tsainez*