### PR TITLE
🎨 Palette: Add tooltip explaining disabled Save/Load button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -46,3 +46,6 @@
 ## 2024-06-18 - Rapid Pagination in Scrollable Lists
 **Learning:** Keyboard navigation in scrollable Pygame UI components (like `FileDialog`) can feel slow when users must press up/down for every single item, degrading accessibility and user experience.
 **Action:** Implement rapid pagination support by handling `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN` to jump by the maximum visible items (`max_visible_files`), significantly speeding up navigation.
+## 2024-05-24 - Tooltips for Disabled States in Pygame
+**Learning:** Pygame UIs often lack native support for conveying why an element is disabled. Users can get confused when a "Save" or "Load" button is unresponsive.
+**Action:** Always draw a contextual tooltip with a semi-transparent background near disabled interactive elements when they are hovered to explain the required action (e.g., "Filename required").

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -324,3 +324,15 @@ class FileDialog:
         btn_text_color = (255, 255, 255) if action_enabled else (200, 200, 200)
         btn_surf = self.font.render(btn_text, True, btn_text_color)
         self.screen.blit(btn_surf, (self.action_button_rect.x + 10, self.action_button_rect.y + 5))
+
+        # Tooltip for disabled action button
+        if self.hovered_element == "action" and not action_enabled:
+            tt_font = pygame.font.SysFont("arial", 16) if pygame.font.get_init() else self.font
+            tt_text = tt_font.render("Filename required", True, (255, 255, 255))
+            tt_rect = tt_text.get_rect(bottomright=(self.action_button_rect.right, self.action_button_rect.top - 5))
+            bg_rect = tt_rect.inflate(10, 6)
+            s = pygame.Surface(bg_rect.size, pygame.SRCALPHA)
+            s.fill((0, 0, 0, 200))
+            self.screen.blit(s, bg_rect.topleft)
+            pygame.draw.rect(self.screen, (150, 150, 150), bg_rect, 1)
+            self.screen.blit(tt_text, tt_rect)


### PR DESCRIPTION
💡 What: Add a tooltip when hovering over the disabled Save/Load button in the FileDialog.
🎯 Why: To explain why the button is unavailable (e.g., "Filename required"), improving user understanding.
📸 Before/After: Visual feedback added.
♿ Accessibility: Improved cognitive accessibility by clarifying system state.

---
*PR created automatically by Jules for task [13920244348448955069](https://jules.google.com/task/13920244348448955069) started by @tsainez*