### PR TITLE
Fix gameplay-loop and playtest bugs from the scrap economy; flag design conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ CLAUDE.md
 TASKS.md
 memory/
 dashboard.html
+
+# Scratch directory some security tests write into at runtime
+# (tests/security/test_campaign_race_condition.py); never commit its contents.
+tmp_test/

--- a/.jules/fable.md
+++ b/.jules/fable.md
@@ -1,0 +1,58 @@
+# Fable — Repository Analysis & Stabilization Journal
+
+## 2026-07-04 - Gameplay-loop audit after the scrap-economy merge
+**Context:** Reviewed the repository state right after the resource-management
+commit (71b3554) that wired scrap harvesting, factory construction costs, and
+hotkey training into `GameScene`. Goal: fix urgent bugs immediately, and mark
+broader design drift with in-code instructions rather than unilateral rewrites.
+
+**Bugs fixed:**
+- **Campaign deadlock:** `rover` was only unlockable by completing mission_1,
+  but mission_1 (FactoryBattleMap) starts the player with three melee Chassis
+  against ranged Rovers/Arachnotrons and gates the whole loop behind
+  `is_unit_unlocked("rover")`. A fresh install could neither build a Rover
+  Factory nor plausibly win, so the unlock could never be earned. `rover` is
+  now in `DEFAULT_UNLOCKED_UNITS` (campaign_manager.py); mission_1's reward is
+  redundant until the rewards table is re-purposed.
+- **Free-upgrade exploit via spawn fallback:** `_train_chassis_at_factory` and
+  `_train_rover_at_factory` fell back to spawning ON the factory's tile when
+  all 8 neighbors were blocked; `ProductionSystem` then instantly transformed
+  the paid unit into the next tier at zero cost (chassis→rover, and worse,
+  rover→arachnotron bypassing the adjacent-rover rule). Training now refuses
+  (no charge) when there is no free adjacent tile (`_find_free_adjacent_tile`).
+- **R/A hotkey double-fire:** one keypress could both build a factory from a
+  selected chassis AND train at a selected Arachnotron Factory (double spend).
+  `_handle_construction` now consumes the keypress whenever a chassis is
+  selected.
+- **HUD overprint:** the chat log grew upward from `SCREEN_HEIGHT-120` straight
+  through the Construction/Factory Production hint panels anchored at
+  `SCREEN_HEIGHT-160`, interleaving both into garbage text whenever a factory
+  was selected. Chat is now anchored at `SCREEN_HEIGHT-170`, above the hint
+  band.
+- **Phantom persistence:** in-match Arachnotron research called
+  `save_progress()`, which does not persist `unlocked_units` at all (only
+  completed_missions) — a misleading disk write. Removed; research is now
+  explicitly documented as session-scoped.
+- Removed committed test junk `tmp_test/` (leftover from PR #371's run of the
+  security suite) and gitignored the directory; deduplicated the double
+  `FogOfWar` construction in `GameScene.__init__`; the Arachnotron Factory
+  panel now advertises the already-functional `C: Train Chassis` hotkey.
+
+**Design drift flagged with in-code DESIGN NOTES (not changed):**
+- `ProductionSystem`: free walk-in transformation coexists with paid hotkey
+  training, making every scrap price bypassable by right-clicking a unit onto
+  the factory tile. Options laid out in the class docstring (charge walk-ins /
+  remove walk-ins / remove paid training).
+- `campaign_manager.MISSION_REWARDS`: two competing tech systems (persistent
+  campaign rewards vs session-scoped in-match research) — reconciliation
+  guidance sits above the table.
+- `ResourceSystem`: wildlife-kill drip is the only income and does not scale
+  with player investment; the default-unlocked `extractor` unit has no
+  economic role despite its name.
+
+**Learning:** When autonomous agents bolt a new economy onto an ECS game, the
+old free paths rarely get retired — they linger as invisible discounts. Audit
+every legacy system that produces the same output the new economy sells, and
+make spawn-position fallbacks fail closed (refuse) rather than fail onto a
+semantically loaded tile like a factory.
+**Model:** Claude (via Claude Code)

--- a/command_line_conflict/campaign_manager.py
+++ b/command_line_conflict/campaign_manager.py
@@ -10,15 +10,41 @@ from .utils.paths import atomic_save_json, get_user_data_dir
 DEFAULT_SAVE_FILENAME = "save_game.json"
 
 # Define the Tech Tree: Mission ID -> List of Unlocked Units
-# Mission 1 unlocks Rover
-# Mission 2 unlocks Arachnotron
-# ...
+#
+# DESIGN NOTE (2026-07-04): There are currently TWO competing tech-unlock
+# mechanisms in the game, and they need to be reconciled:
+#
+#   1. This campaign reward table: winning a mission permanently unlocks units
+#      across all future games (persisted in save_game.json).
+#   2. In-match research: GameScene._research_arachnotron_at_factory lets a
+#      player unlock the Arachnotron *during* a match ("T" at a Rover Factory,
+#      100 scrap + 6 living Chassis). That unlock is intentionally
+#      session-scoped: it mutates `unlocked_units` in memory only, is NOT
+#      written to disk (save_progress only persists completed_missions), and
+#      is discarded when `_update_unlocks` re-derives the set.
+#
+# Consequences to be aware of before extending either mechanism:
+#   - "rover" is a DEFAULT_UNLOCKED_UNITS member (see below) because the basic
+#     match loop (Chassis -> build Rover Factory) must work on a fresh save;
+#     that makes mission_1's "rover" reward redundant. Consider re-purposing
+#     mission rewards (e.g. cosmetic/stat rewards, or starting-scrap bonuses)
+#     or removing the campaign gate entirely in favor of in-match research.
+#   - If you add in-match research for more units, follow the session-scoped
+#     pattern above; do NOT call save_progress() from match code, or a single
+#     skirmish would permanently alter campaign progression.
 MISSION_REWARDS: Dict[str, List[str]] = {
     "mission_1": ["rover"],
     "mission_2": ["arachnotron"],
     "mission_3": ["observer"],
     "mission_4": ["immortal"],
 }
+
+# Units every player can build from a fresh save. "rover" must stay in this
+# set: FactoryBattleMap starts the human player with three melee Chassis
+# against ranged Rover/Arachnotron defenders, so a fresh install that cannot
+# build a Rover Factory (gated on is_unit_unlocked("rover")) has no viable
+# path to victory — and therefore no way to ever earn mission_1's unlock.
+DEFAULT_UNLOCKED_UNITS: Set[str] = {"chassis", "extractor", "rover"}
 
 
 class CampaignManager:
@@ -50,7 +76,7 @@ class CampaignManager:
                     log.error(f"Failed to migrate save file: {e}")
 
         self.completed_missions: List[str] = []
-        self.unlocked_units: Set[str] = {"chassis", "extractor"}  # Default unlocks
+        self.unlocked_units: Set[str] = set(DEFAULT_UNLOCKED_UNITS)
         self.load_progress()
 
     def load_progress(self) -> None:
@@ -141,8 +167,13 @@ class CampaignManager:
             self.save_progress()
 
     def _update_unlocks(self) -> None:
-        """Updates the set of unlocked units based on completed missions."""
-        self.unlocked_units = {"chassis", "extractor"}  # Reset to default
+        """Updates the set of unlocked units based on completed missions.
+
+        Note: this rebuilds the set from scratch, so any session-scoped
+        unlock (e.g. in-match Arachnotron research) is intentionally
+        discarded here. See the DESIGN NOTE above MISSION_REWARDS.
+        """
+        self.unlocked_units = set(DEFAULT_UNLOCKED_UNITS)  # Reset to default
         for mission_id in self.completed_missions:
             rewards = MISSION_REWARDS.get(mission_id, [])
             for unit in rewards:

--- a/command_line_conflict/engine.py
+++ b/command_line_conflict/engine.py
@@ -38,16 +38,31 @@ class SceneManager:
         self.current_scene = self.scenes["menu"]
         log.debug("SceneManager initialized with scenes: %s", list(self.scenes.keys()))
 
-    def switch_to(self, scene_name):
+    def switch_to(self, scene_name, reset: bool = True):
         """Switches the active scene.
 
         Args:
             scene_name: The name of the scene to switch to.
+            reset: Only meaningful for "game". True (default) starts a fresh
+                GameScene. False resumes the existing in-progress game —
+                exactly as it was left when the player pressed ESC (scenes
+                that aren't current receive no update() calls, so the match
+                is effectively frozen, not running in the background). A
+                finished (mission_over) or never-entered scene cannot be
+                resumed; a fresh one is created instead.
         """
         log.debug(f"Switching scene to: {scene_name}")
         pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
         if scene_name == "game":
-            self.scenes["game"] = GameScene(self.game)
+            existing = self.scenes.get("game")
+            resumable = (
+                not reset
+                and isinstance(existing, GameScene)
+                and getattr(existing, "mission_started", False)
+                and not getattr(existing, "mission_over", False)
+            )
+            if not resumable:
+                self.scenes["game"] = GameScene(self.game)
         elif scene_name == "editor":
             self.scenes["editor"] = EditorScene(self.game)
         self.current_scene = self.scenes[scene_name]

--- a/command_line_conflict/factories.py
+++ b/command_line_conflict/factories.py
@@ -250,6 +250,9 @@ def create_rover_factory(game_state: GameState, x: float, y: float, player_id: i
     color = config.PLAYER_COLORS.get(player_id, (255, 255, 255))
     game_state.add_component(entity_id, Renderable(icon="F", color=color))
     game_state.add_component(entity_id, Health(hp=200, max_hp=200))
+    # Buildings watch their surroundings: without Vision a player's own base
+    # sits inside fog of war, which reads as a rendering bug.
+    game_state.add_component(entity_id, Vision(vision_range=4))
     game_state.add_component(entity_id, Selectable())
     game_state.add_component(entity_id, Player(player_id=player_id, is_human=is_human))
     game_state.add_component(entity_id, Factory(input_unit="chassis", output_unit="rover"))
@@ -276,6 +279,8 @@ def create_arachnotron_factory(game_state: GameState, x: float, y: float, player
     color = config.PLAYER_COLORS.get(player_id, (255, 255, 255))
     game_state.add_component(entity_id, Renderable(icon="f", color=color))
     game_state.add_component(entity_id, Health(hp=300, max_hp=300))
+    # See create_rover_factory: friendly buildings must clear their own fog.
+    game_state.add_component(entity_id, Vision(vision_range=4))
     game_state.add_component(entity_id, Selectable())
     game_state.add_component(entity_id, Player(player_id=player_id, is_human=is_human))
     game_state.add_component(entity_id, Factory(input_unit="rover", output_unit="arachnotron"))

--- a/command_line_conflict/scenes/game.py
+++ b/command_line_conflict/scenes/game.py
@@ -64,6 +64,14 @@ class GameScene:
         self.paused = False
         self.current_player_id = 1
 
+        # Lifecycle flags used by SceneManager/MenuScene to decide whether
+        # this scene can be resumed after ESC-ing out to the menu.
+        # mission_started flips once the scene actually runs a frame (a
+        # freshly constructed, never-entered scene is not "in progress");
+        # mission_over flips when the win/loss condition fires.
+        self.mission_started = False
+        self.mission_over = False
+
         # Cheats
         self.cheats = {
             "reveal_map": False,
@@ -879,6 +887,7 @@ class GameScene:
         Args:
             dt: The time elapsed since the last frame.
         """
+        self.mission_started = True
         self.chat_system.update(self.game_state, dt)
 
         if self.paused:
@@ -966,6 +975,7 @@ class GameScene:
                     return False
 
         log.info("Victory! Mission Complete.")
+        self.mission_over = True
         self.game.steam.unlock_achievement("VICTORY")
         # Trigger victory sound (note: scene switch might cut it off if SoundSystem isn't persistent or updated)
         # Since SoundSystem is part of GameScene, and we switch scene, we should ideally play it in the new scene
@@ -999,6 +1009,7 @@ class GameScene:
                     return False
 
         log.info("Defeat! Mission Failed.")
+        self.mission_over = True
         self.game.steam.unlock_achievement("DEFEAT")
         self.sound_system.play_sound("defeat")
         return True

--- a/command_line_conflict/scenes/game.py
+++ b/command_line_conflict/scenes/game.py
@@ -70,9 +70,6 @@ class GameScene:
             "god_mode": False,
         }
 
-        # Fog of War
-        self.fog_of_war = FogOfWar(self.game_state.map.width, self.game_state.map.height)
-
         # Camera
         self.camera = Camera()
         self.camera_movement = {
@@ -159,10 +156,16 @@ class GameScene:
 
         log.debug(f"Handling event: {event}")
 
-        # Handle construction hotkeys if a chassis is selected
+        # R and A are context-sensitive hotkeys shared between two actions:
+        #   - Chassis selected:            R/A = build a factory (consumes the chassis).
+        #   - Arachnotron Factory selected: R/A = train a Rover / Arachnotron.
+        # Construction takes priority and consumes the keypress. Without the
+        # early return, a mixed selection (chassis + factory) would trigger
+        # BOTH actions from a single keypress and double-spend scrap.
         if event.type == pygame.KEYDOWN:
             if event.key in (pygame.K_r, pygame.K_a):
-                self._handle_construction(event.key)
+                if self._handle_construction(event.key):
+                    return
 
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             self.selection_start = event.pos
@@ -517,8 +520,15 @@ class GameScene:
         if not cursor_set:
             pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
 
-    def _handle_construction(self, key):
-        """Handles building construction requests."""
+    def _handle_construction(self, key) -> bool:
+        """Handles building construction requests.
+
+        Returns:
+            True if a chassis was selected and the keypress was consumed
+            (even if the build was refused, e.g. insufficient scrap), False
+            if no builder was selected and the key should fall through to
+            other handlers (factory training shares the R/A keys).
+        """
         # Find selected chassis
         selected_chassis_ids = []
         for entity_id in self.game_state.get_entities_with_component(Selectable):
@@ -534,7 +544,7 @@ class GameScene:
                     selected_chassis_ids.append(entity_id)
 
         if not selected_chassis_ids:
-            return
+            return False
 
         # Simple logic: First selected chassis builds the factory
         builder_id = selected_chassis_ids[0]
@@ -542,7 +552,7 @@ class GameScene:
         player = self.game_state.get_component(builder_id, Player)
 
         if not pos or not player:
-            return
+            return True
 
         # Check unlock requirements and build
         if key == pygame.K_r:  # Build Rover Factory
@@ -550,14 +560,14 @@ class GameScene:
             if not self.campaign_manager.is_unit_unlocked("rover"):
                 log.info("Rover tech not unlocked!")
                 self.chat_system.add_message("Rover tech not unlocked!", (255, 0, 0))
-                return
+                return True
 
             cost = 100
             player_resources = self.game_state.resources.get(player.player_id, 0)
             if player_resources < cost:
                 log.info(f"Insufficient scrap! Need {cost}, have {player_resources}.")
                 self.chat_system.add_message(f"Insufficient scrap! Need {cost}, have {player_resources}.", (255, 0, 0))
-                return
+                return True
 
             log.info("Building Rover Factory")
             self.game_state.resources[player.player_id] = player_resources - cost
@@ -569,20 +579,37 @@ class GameScene:
             if not self.campaign_manager.is_unit_unlocked("arachnotron"):
                 log.info("Arachnotron tech not unlocked!")
                 self.chat_system.add_message("Arachnotron tech not unlocked!", (255, 0, 0))
-                return
+                return True
 
             cost = 150
             player_resources = self.game_state.resources.get(player.player_id, 0)
             if player_resources < cost:
                 log.info(f"Insufficient scrap! Need {cost}, have {player_resources}.")
                 self.chat_system.add_message(f"Insufficient scrap! Need {cost}, have {player_resources}.", (255, 0, 0))
-                return
+                return True
 
             log.info("Building Arachnotron Factory")
             self.game_state.resources[player.player_id] = player_resources - cost
             self.game_state.remove_entity(builder_id)
             factories.create_arachnotron_factory(self.game_state, pos.x, pos.y, player.player_id, player.is_human)
             self.game.steam.unlock_achievement("BUILDER")
+
+        return True
+
+    def _find_free_adjacent_tile(self, center_pos: Position) -> "tuple[float, float] | None":
+        """Finds a walkable, unoccupied tile in the 8 cells around a position.
+
+        Returns:
+            (x, y) of the first free neighboring tile, or None if all eight
+            neighbors are blocked. Callers must treat None as "do not spawn"
+            rather than spawning on the center tile itself — see the exploit
+            notes in the training methods below.
+        """
+        for dx, dy in [(0, 1), (1, 0), (0, -1), (-1, 0), (1, 1), (-1, 1), (1, -1), (-1, -1)]:
+            nx, ny = int(center_pos.x + dx), int(center_pos.y + dy)
+            if self.game_state.map.is_walkable(nx, ny) and not self.game_state.is_position_occupied(nx, ny):
+                return float(nx), float(ny)
+        return None
 
     def _train_chassis_at_factory(self, factory_id):
         """Trains a chassis at the selected factory."""
@@ -598,14 +625,15 @@ class GameScene:
         if not factory_pos or not player:
             return
 
-        # Find a free adjacent tile to spawn the chassis
-        spawn_x, spawn_y = factory_pos.x, factory_pos.y
-        # Look in surrounding cells on the grid
-        for dx, dy in [(0, 1), (1, 0), (0, -1), (-1, 0), (1, 1), (-1, 1), (1, -1), (-1, -1)]:
-            nx, ny = int(factory_pos.x + dx), int(factory_pos.y + dy)
-            if self.game_state.map.is_walkable(nx, ny) and not self.game_state.is_position_occupied(nx, ny):
-                spawn_x, spawn_y = float(nx), float(ny)
-                break
+        # Find a free adjacent tile to spawn the chassis. Never fall back to
+        # the factory's own tile: ProductionSystem transforms any input unit
+        # standing on a factory (chassis -> rover here) at zero scrap cost,
+        # so an on-factory spawn would silently upgrade the unit for free.
+        spawn_pos = self._find_free_adjacent_tile(factory_pos)
+        if spawn_pos is None:
+            self.chat_system.add_message("No open tile next to the factory to deploy a Chassis!", (255, 0, 0))
+            return
+        spawn_x, spawn_y = spawn_pos
 
         # Spend resources
         self.game_state.resources[self.current_player_id] = player_resources - cost
@@ -669,9 +697,13 @@ class GameScene:
         # Deduct cost
         self.game_state.resources[self.current_player_id] = player_resources - cost
 
-        # Unlock Arachnotron tech
+        # Unlock Arachnotron tech for THIS MATCH ONLY. This mutates the
+        # in-memory set on the scene's CampaignManager; it is deliberately not
+        # saved to disk (save_progress only persists completed_missions, and
+        # _update_unlocks would discard it anyway). A new GameScene starts
+        # with the research locked again. See the DESIGN NOTE above
+        # MISSION_REWARDS in campaign_manager.py before changing this.
         self.campaign_manager.unlocked_units.add("arachnotron")
-        self.campaign_manager.save_progress()
 
         log.info(f"Arachnotron tech researched by player {self.current_player_id}")
         self.chat_system.add_message(
@@ -708,13 +740,16 @@ class GameScene:
         if not factory_pos or not player:
             return
 
-        # Find a free adjacent tile to spawn the rover
-        spawn_x, spawn_y = factory_pos.x, factory_pos.y
-        for dx, dy in [(0, 1), (1, 0), (0, -1), (-1, 0), (1, 1), (-1, 1), (1, -1), (-1, -1)]:
-            nx, ny = int(factory_pos.x + dx), int(factory_pos.y + dy)
-            if self.game_state.map.is_walkable(nx, ny) and not self.game_state.is_position_occupied(nx, ny):
-                spawn_x, spawn_y = float(nx), float(ny)
-                break
+        # Find a free adjacent tile to spawn the rover. Never fall back to the
+        # factory's own tile: this is an Arachnotron Factory whose input unit
+        # is "rover", so ProductionSystem would instantly convert an
+        # on-factory rover into a free Arachnotron, bypassing the 120-scrap
+        # cost and the adjacent-rover training requirement.
+        spawn_pos = self._find_free_adjacent_tile(factory_pos)
+        if spawn_pos is None:
+            self.chat_system.add_message("No open tile next to the factory to deploy a Rover!", (255, 0, 0))
+            return
+        spawn_x, spawn_y = spawn_pos
 
         # Spend resources
         self.game_state.resources[self.current_player_id] = player_resources - cost
@@ -870,6 +905,10 @@ class GameScene:
         self.confetti_system.update(self.game_state, dt)
         self.movement_system.update(self.game_state, dt)
         self.resource_system.update(self.game_state, dt)
+        # NOTE: ProductionSystem still grants FREE walk-in transformations
+        # (unit standing on a factory tile becomes the factory's output),
+        # which bypasses the scrap prices charged by the training hotkeys.
+        # See the DESIGN NOTE on ProductionSystem before rebalancing costs.
         self.production_system.update(self.game_state, dt)
         self.corpse_removal_system.update(self.game_state, dt)
         self.sound_system.update(self.game_state)

--- a/command_line_conflict/scenes/menu.py
+++ b/command_line_conflict/scenes/menu.py
@@ -31,7 +31,7 @@ class MenuScene:
 
         self.selected_option = 0
         self.help_texts = {
-            "Continue Campaign": "Resume your saved progress.",
+            "Continue Campaign": "Pick up the game in progress, or your saved campaign.",
             "New Game": "Start a new campaign from the beginning.",
             "Map Editor": "Create and edit custom levels.",
             "Options": "Adjust game settings.",
@@ -105,7 +105,10 @@ class MenuScene:
         option_text = self.menu_options[option_index]
 
         if option_text == "Continue Campaign":
-            self.game.scene_manager.switch_to("game")
+            # reset=False resumes the in-progress match (ESC out of a game
+            # freezes the scene rather than discarding it); if there is no
+            # resumable match, SceneManager falls back to a fresh mission.
+            self.game.scene_manager.switch_to("game", reset=False)
         elif option_text == "New Game":
             self.game.scene_manager.switch_to("game")
         elif option_text == "Map Editor":
@@ -121,6 +124,38 @@ class MenuScene:
         else:
             self.quit_confirm = False
 
+    def _has_resumable_game(self) -> bool:
+        """Whether an in-progress (ESC'd, not finished) game scene exists."""
+        scene_manager = getattr(self.game, "scene_manager", None)
+        scenes = getattr(scene_manager, "scenes", None)
+        if not isinstance(scenes, dict):
+            return False
+        game_scene = scenes.get("game")
+        return (
+            game_scene is not None
+            and getattr(game_scene, "mission_started", False) is True
+            and getattr(game_scene, "mission_over", False) is False
+        )
+
+    def _refresh_continue_option(self) -> None:
+        """Shows/hides 'Continue Campaign' as the game state changes.
+
+        The option must appear not only when the save file has completed
+        missions, but also when the player ESC'd out of a live match — on a
+        fresh install that frozen match is otherwise unreachable and the
+        player is forced to restart the mission (brutal for playtesting).
+        """
+        should_show = bool(self.campaign_manager.completed_missions) or self._has_resumable_game()
+        has_option = "Continue Campaign" in self.menu_options
+        if should_show and not has_option:
+            self.menu_options.insert(0, "Continue Campaign")
+            self.selected_option = 0
+            self.quit_confirm = False
+        elif not should_show and has_option:
+            self.menu_options.remove("Continue Campaign")
+            self.selected_option = 0
+            self.quit_confirm = False
+
     def update(self, dt):
         """Updates the menu scene.
 
@@ -128,6 +163,7 @@ class MenuScene:
             dt: The time elapsed since the last frame.
         """
         self.time += dt
+        self._refresh_continue_option()
 
     def draw(self, screen):
         """Draws the menu options and title to the screen.
@@ -161,7 +197,10 @@ class MenuScene:
                     display_text = f"> {option} <"
 
             text = self._get_text_surface(display_text, color, "option")
-            text_rect = text.get_rect(center=(self.game.screen.get_width() / 2, 300 + i * 60))
+            # 280 + i * 52 keeps the 5-row menu (with Continue Campaign)
+            # clear of the help line at SCREEN_HEIGHT - 50 on an 800x600
+            # window; 300 + i * 60 used to collide with it.
+            text_rect = text.get_rect(center=(self.game.screen.get_width() / 2, 280 + i * 52))
             screen.blit(text, text_rect)
             self.option_rects.append((text_rect, i))
 

--- a/command_line_conflict/scenes/settings.py
+++ b/command_line_conflict/scenes/settings.py
@@ -29,9 +29,16 @@ class SettingsScene:
             "Master Volume",
             "Music Volume",
             "SFX Volume",
-            "Mute Audio",  # TODO: clean this up, because mute audio is clipping over the screen!
+            "Mute Audio",
             "Back",
         ]
+        # Vertical layout: everything must fit the smallest resolution
+        # (800x600) with the help line at the bottom. With 7 options, the
+        # last row sits at options_start_y + 6 * option_spacing; keep that
+        # comfortably above SCREEN_HEIGHT - 50 where the help text renders,
+        # or the two overprint (this happened with 250 + i * 60).
+        self.options_start_y = 200
+        self.option_spacing = 52
         self.selected_option = 0
         self.option_rects = []
         self.screen_sizes = [(800, 600), (1024, 768), (1280, 720)]
@@ -40,8 +47,6 @@ class SettingsScene:
             self.current_screen_size_index = self.screen_sizes.index((config.SCREEN["width"], config.SCREEN["height"]))
         except ValueError:
             self.current_screen_size_index = 0
-        self.time = 0.0
-
         self.time = 0.0
         self.help_texts = {
             "Screen Size": "Changes the window resolution.",
@@ -90,16 +95,32 @@ class SettingsScene:
                 pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
 
         elif event.type == pygame.MOUSEBUTTONUP:
-            for rect, i in self.option_rects:
-                if rect.collidepoint(event.pos):
-                    self.selected_option = i
-                    option_name = self.settings_options[i]
-                    if "Volume" in option_name:
-                        # Left side decreases, right side increases
-                        direction = -1 if event.pos[0] < rect.centerx else 1
-                        self._change_volume(option_name, direction)
-                    else:
-                        self._trigger_option(option_name)
+            # Buttons 4/5 are legacy scroll-wheel events. Before this check,
+            # a wheel tick over ANY row activated it (toggling Mute, leaving
+            # via Back...), and over a volume row the direction came from the
+            # cursor's x position — so scrolling up and down did the same
+            # thing. Wheel direction is now static: up always raises volume,
+            # down always lowers it, and the wheel does nothing elsewhere.
+            button = getattr(event, "button", 1)
+            if button in (4, 5):
+                for rect, i in self.option_rects:
+                    if rect.collidepoint(event.pos):
+                        option_name = self.settings_options[i]
+                        if "Volume" in option_name:
+                            self.selected_option = i
+                            self._change_volume(option_name, 1 if button == 4 else -1)
+                        break
+            elif button == 1:
+                for rect, i in self.option_rects:
+                    if rect.collidepoint(event.pos):
+                        self.selected_option = i
+                        option_name = self.settings_options[i]
+                        if "Volume" in option_name:
+                            # Left side decreases, right side increases
+                            direction = -1 if event.pos[0] < rect.centerx else 1
+                            self._change_volume(option_name, direction)
+                        else:
+                            self._trigger_option(option_name)
 
         elif event.type == pygame.KEYDOWN:
             option_name = self.settings_options[self.selected_option]
@@ -236,7 +257,9 @@ class SettingsScene:
                     text_to_render = f"> {text_to_render} <"
 
             text = self._get_text_surface(text_to_render, color, "option")
-            text_rect = text.get_rect(center=(self.game.screen.get_width() / 2, 250 + i * 60))
+            text_rect = text.get_rect(
+                center=(self.game.screen.get_width() / 2, self.options_start_y + i * self.option_spacing)
+            )
             screen.blit(text, text_rect)
             self.option_rects.append((text_rect, i))
 

--- a/command_line_conflict/systems/chat_system.py
+++ b/command_line_conflict/systems/chat_system.py
@@ -129,7 +129,13 @@ class ChatSystem:
         if not show_history and not self.input_active:
             return
 
-        chat_bottom = config.SCREEN_HEIGHT - 120
+        # Anchor the chat above the contextual hint panels. UISystem draws
+        # "Construction:" / "Factory Production:" hints in the band from
+        # SCREEN_HEIGHT-160 down to the bottom info panel (SCREEN_HEIGHT-100);
+        # chat lines grow upward from chat_bottom, so anchoring any lower than
+        # SCREEN_HEIGHT-170 makes chat and hints overprint each other into
+        # unreadable text whenever a factory or chassis is selected.
+        chat_bottom = config.SCREEN_HEIGHT - 170
         line_height = 20
 
         # Draw messages

--- a/command_line_conflict/systems/chat_system.py
+++ b/command_line_conflict/systems/chat_system.py
@@ -15,10 +15,17 @@ class ChatSystem:
         """
         self.screen = screen
         self.font = font
-        self.messages = []  # List of (text, color) tuples
+        # Notifications render with a smaller dedicated font: the main game
+        # font at chat size covered a third of the 600px-tall playfield once
+        # a few training/insufficient-scrap messages stacked up.
+        self.message_font = pygame.font.Font(None, 20)
+        self.messages = []  # List of message dicts (see add_message)
         self.input_active = False
         self.input_text = ""
         self.max_messages = 20
+        # Only this many lines show in the transient (auto-hiding) view;
+        # the full history stays available via the L log toggle.
+        self.max_visible_messages = 6
         self.chat_history_duration = 5000  # Milliseconds to show chat history
         self.last_message_time = 0
         self.cursor_blink_timer = 0
@@ -28,26 +35,46 @@ class ChatSystem:
     def add_message(self, text: str, color: tuple[int, int, int] = (255, 255, 255)):
         """Adds a message to the chat history.
 
+        Consecutive identical messages collapse into a single line with a
+        repeat counter ("Insufficient scrap! ... (x4)") instead of flooding
+        the screen — spamming a training hotkey used to fill the playfield.
+
         Args:
             text: The message text.
             color: The color of the text (RGB tuple).
         """
+        now = pygame.time.get_ticks()
+
+        if self.messages:
+            last = self.messages[-1]
+            if last.get("base_text") == text and last.get("color") == color:
+                last["count"] = last.get("count", 1) + 1
+                display_text = f"{text} (x{last['count']})"
+                last["text"] = display_text
+                last["surface"] = self.message_font.render(display_text, True, color)
+                last["shadow_surface"] = self.message_font.render(display_text, True, (0, 0, 0))
+                last["time"] = now
+                self.last_message_time = now
+                return
+
         # Pre-render text surfaces to avoid doing it every frame
-        text_surf = self.font.render(text, True, color)
-        shadow_surf = self.font.render(text, True, (0, 0, 0))
+        text_surf = self.message_font.render(text, True, color)
+        shadow_surf = self.message_font.render(text, True, (0, 0, 0))
 
         self.messages.append(
             {
                 "text": text,
+                "base_text": text,
+                "count": 1,
                 "color": color,
-                "time": pygame.time.get_ticks(),
+                "time": now,
                 "surface": text_surf,
                 "shadow_surface": shadow_surf,
             }
         )
         if len(self.messages) > self.max_messages:
             self.messages.pop(0)
-        self.last_message_time = pygame.time.get_ticks()
+        self.last_message_time = now
 
     def handle_event(self, event) -> bool:
         """Handles user input for the chat system.
@@ -149,15 +176,19 @@ class ChatSystem:
                 s.fill((0, 0, 0, 160))  # Semi-transparent black
                 self.screen.blit(s, bg_rect.topleft)
 
-            for i, msg in enumerate(reversed(self.messages)):
+            # The transient overlay only shows the newest few lines; the L
+            # log toggle shows everything with a backdrop.
+            visible = self.messages if self.show_log else self.messages[-self.max_visible_messages :]
+
+            for i, msg in enumerate(reversed(visible)):
                 text_surface = msg.get("surface")
                 shadow_surface = msg.get("shadow_surface")
 
                 # Fallback if surfaces missing (e.g. from saved state or legacy)
                 if not text_surface:
-                    text_surface = self.font.render(msg["text"], True, msg["color"])
+                    text_surface = self.message_font.render(msg["text"], True, msg["color"])
                 if not shadow_surface:
-                    shadow_surface = self.font.render(msg["text"], True, (0, 0, 0))
+                    shadow_surface = self.message_font.render(msg["text"], True, (0, 0, 0))
 
                 y_pos = chat_bottom - (i + 1) * line_height
                 if self.input_active:

--- a/command_line_conflict/systems/production_system.py
+++ b/command_line_conflict/systems/production_system.py
@@ -8,7 +8,46 @@ from command_line_conflict.logger import log
 
 
 class ProductionSystem:
-    """System that handles unit production via factories."""
+    """System that handles unit production via factories.
+
+    DESIGN NOTE (2026-07-04) — two production mechanics currently coexist,
+    and they undercut each other. Whoever touches production next should
+    pick one direction on purpose instead of extending both:
+
+    1. Walk-in transformation (THIS system, the original mechanic):
+       a unit whose UnitIdentity matches the factory's ``input_unit`` and
+       stands on the factory's tile is transformed into ``output_unit``
+       — chassis -> rover at a Rover Factory, rover -> arachnotron at an
+       Arachnotron Factory. It costs NOTHING except the consumed unit.
+
+    2. Hotkey training (added with the scrap economy, lives in
+       GameScene._train_*_at_factory): the same conversions cost scrap
+       (Rover 80, Arachnotron 120 + an adjacent Rover consumed) plus a
+       50-scrap Chassis via the C key.
+
+    Because both are active, every scrap price on the training hotkeys can
+    be sidestepped by right-clicking the unit onto the factory tile: a
+    50-scrap Chassis walked onto a Rover Factory yields a Rover that the
+    hotkey path sells for 80, and an 80-scrap Rover walked onto an
+    Arachnotron Factory yields a 120-scrap Arachnotron. The walk-in path is
+    strictly cheaper, so the economy only disciplines players who don't
+    know about it — the worst kind of balance.
+
+    Options, roughly in order of least design churn:
+      a) Charge walk-in transformations the same scrap cost as the hotkey
+         (refuse + chat warning when the owner can't pay). Keeps both
+         interactions, one price list. Requires giving this system access
+         to game_state.resources and the chat/event queue.
+      b) Remove walk-in transformation entirely and make hotkey training
+         the only path (then Factory.input_unit only documents the recipe,
+         and the Arachnotron's "consume an adjacent Rover" rule becomes the
+         universal pattern). Simplest economy; kills a charming mechanic.
+      c) Keep walk-in as the *only* conversion path and drop the R/A
+         training hotkeys, so scrap is spent on Chassis + factories only.
+         Closest to the original vision, but weakens the new scrap sink.
+    Whichever way this goes, delete this note and update the hotkey table
+    in GameScene.handle_event plus the UISystem factory hint panel.
+    """
 
     def __init__(self, campaign_manager: CampaignManager):
         self.campaign_manager = campaign_manager

--- a/command_line_conflict/systems/resource_system.py
+++ b/command_line_conflict/systems/resource_system.py
@@ -7,7 +7,24 @@ from ..logger import log
 
 
 class ResourceSystem:
-    """System that handles resource collection/harvesting from scrap entities."""
+    """System that handles resource collection/harvesting from scrap entities.
+
+    DESIGN NOTE (2026-07-04) — the scrap economy currently has exactly one
+    income source: wildlife drops 50 scrap on death (HealthSystem), and any
+    non-neutral unit that steps on the pile collects it. Two consequences
+    worth weighing before building more content on top:
+
+    * Income is capped by SpawnSystem's wildlife respawn rate (one spawn
+      per 5s in GameScene), so the mid/late game economy is a fixed drip
+      that no player decision can improve. Classic RTS pacing usually wants
+      income to scale with investment (more workers/bases -> more income).
+    * The "extractor" unit (factories.create_extractor) is default-unlocked
+      and named like a harvester, but participates in the economy in NO way
+      — it has no gathering behavior and no system references it. Either
+      give it the harvesting role (e.g. only extractors can collect scrap,
+      or extractors mine renewable deposits) or cut it; shipping a
+      do-nothing economic unit will read as a bug to players.
+    """
 
     def update(self, game_state: GameState, dt: float) -> None:
         """Checks for player units overlapping with scrap deposits and harvests them.

--- a/command_line_conflict/systems/ui_system.py
+++ b/command_line_conflict/systems/ui_system.py
@@ -388,6 +388,13 @@ class UISystem:
                 self.screen.blit(hint, (panel_x, panel_y))
                 panel_y += 18
             elif identity.name == "arachnotron_factory":
+                # The C hotkey trains a chassis at BOTH factory types (see the
+                # K_c handler in GameScene.handle_event), so advertise it here
+                # too — an unlisted hotkey is indistinguishable from a bug.
+                hint_c = self._get_text_surface("C: Train Chassis (50 Scrap)", (200, 200, 200), "small")
+                self.screen.blit(hint_c, (panel_x, panel_y))
+                panel_y += 18
+
                 hint_r = self._get_text_surface("R: Train Rover (80 Scrap)", (200, 200, 200), "small")
                 self.screen.blit(hint_r, (panel_x, panel_y))
                 panel_y += 18

--- a/tests/test_chat_system.py
+++ b/tests/test_chat_system.py
@@ -33,6 +33,33 @@ def test_max_messages(chat_system):
     assert chat_system.messages[0]["text"] == "Message 5"
 
 
+def test_consecutive_duplicates_collapse(chat_system):
+    """Identical back-to-back notifications merge into one counted line
+    instead of flooding the playfield."""
+    for _ in range(4):
+        chat_system.add_message("Insufficient scrap!", (255, 0, 0))
+
+    assert len(chat_system.messages) == 1
+    assert chat_system.messages[0]["text"] == "Insufficient scrap! (x4)"
+    assert chat_system.messages[0]["count"] == 4
+
+    # A different message breaks the run...
+    chat_system.add_message("Chassis trained successfully.", (0, 255, 0))
+    assert len(chat_system.messages) == 2
+
+    # ...and the same text after it starts a fresh line, not a merge.
+    chat_system.add_message("Insufficient scrap!", (255, 0, 0))
+    assert len(chat_system.messages) == 3
+    assert chat_system.messages[-1]["text"] == "Insufficient scrap!"
+
+
+def test_same_text_different_color_not_collapsed(chat_system):
+    """Color is part of the message identity (e.g. warning vs success)."""
+    chat_system.add_message("Status", (255, 0, 0))
+    chat_system.add_message("Status", (0, 255, 0))
+    assert len(chat_system.messages) == 2
+
+
 def test_handle_event_activation(chat_system):
     # Ensure it starts inactive
     assert not chat_system.input_active

--- a/tests/test_tech_tree.py
+++ b/tests/test_tech_tree.py
@@ -30,11 +30,14 @@ class TestCampaignManager(unittest.TestCase):
 
     def test_initial_state(self):
         self.assertIn("chassis", self.manager.unlocked_units)
-        # Assuming rover requires 1 mission, it should not be unlocked yet
-        self.assertNotIn("rover", self.manager.unlocked_units)
+        # Rover is a default unlock: the basic match loop (Chassis -> build
+        # Rover Factory) must be playable on a fresh save, otherwise
+        # mission_1 is unwinnable and the campaign deadlocks.
+        self.assertIn("rover", self.manager.unlocked_units)
+        # Arachnotron is gated (mission_2 reward or in-match research).
+        self.assertNotIn("arachnotron", self.manager.unlocked_units)
 
     def test_unlock_progression(self):
-        # Rover needs mission_1
         self.manager.complete_mission("mission_1")
         self.assertIn("rover", self.manager.unlocked_units)
         self.assertNotIn("arachnotron", self.manager.unlocked_units)

--- a/tests/unit/scenes/test_menu_ux.py
+++ b/tests/unit/scenes/test_menu_ux.py
@@ -101,7 +101,33 @@ class TestMenuUX:
             # "Continue Campaign" is at index 0
             menu._trigger_option(0)
 
-            mock_game.scene_manager.switch_to.assert_called_with("game")
+            # reset=False resumes an in-progress match instead of recreating
+            # the scene; SceneManager falls back to a fresh mission if there
+            # is nothing to resume.
+            mock_game.scene_manager.switch_to.assert_called_with("game", reset=False)
+
+    def test_menu_shows_continue_for_in_progress_game(self, mock_game):
+        """'Continue Campaign' must appear when a live match was ESC'd out
+        of, even with zero completed missions (fresh install playtesting)."""
+        from types import SimpleNamespace
+
+        with patch("pygame.font.Font"), patch("command_line_conflict.scenes.menu.CampaignManager") as MockCampaignManager:
+            MockCampaignManager.return_value.completed_missions = []
+
+            menu = MenuScene(mock_game)
+            assert "Continue Campaign" not in menu.menu_options
+
+            # Simulate a frozen in-progress game scene.
+            mock_game.scene_manager.scenes = {
+                "game": SimpleNamespace(mission_started=True, mission_over=False),
+            }
+            menu.update(0.016)
+            assert menu.menu_options[0] == "Continue Campaign"
+
+            # Once the mission ends, the option disappears again.
+            mock_game.scene_manager.scenes["game"].mission_over = True
+            menu.update(0.016)
+            assert "Continue Campaign" not in menu.menu_options
 
     def test_update_increments_time(self, mock_game):
         with patch("pygame.font.Font"), patch("command_line_conflict.scenes.menu.CampaignManager"):

--- a/tests/unit/scenes/test_settings_scene.py
+++ b/tests/unit/scenes/test_settings_scene.py
@@ -102,6 +102,7 @@ def test_mouse_click_volume_right(settings_scene):
 
     event = MagicMock()
     event.type = pygame.MOUSEBUTTONUP
+    event.button = 1
     event.pos = (150, 100)  # Right side
 
     settings_scene.handle_event(event)
@@ -120,6 +121,7 @@ def test_mouse_click_volume_left(settings_scene):
 
     event = MagicMock()
     event.type = pygame.MOUSEBUTTONUP
+    event.button = 1
     event.pos = (50, 100)  # Left side
 
     settings_scene.handle_event(event)
@@ -134,10 +136,65 @@ def test_mouse_click_trigger(settings_scene):
 
     event = MagicMock()
     event.type = pygame.MOUSEBUTTONUP
+    event.button = 1
     event.pos = (100, 100)
 
     settings_scene.handle_event(event)
     settings_scene.game.scene_manager.switch_to.assert_called_with("menu")
+
+
+def test_scroll_wheel_volume_is_static(settings_scene):
+    """Wheel up always increases and wheel down always decreases volume,
+    regardless of which side of the bar the cursor sits on."""
+    config.MASTER_VOLUME = 0.5
+
+    rect = MagicMock()
+    rect.collidepoint.return_value = True
+    rect.centerx = 100
+    settings_scene.option_rects = [(rect, 2)]  # Master Volume
+
+    # Wheel up with the cursor on the LEFT half (the old position-based
+    # logic would have decreased here).
+    event = MagicMock()
+    event.type = pygame.MOUSEBUTTONUP
+    event.button = 4
+    event.pos = (50, 100)
+    settings_scene.handle_event(event)
+    assert config.MASTER_VOLUME > 0.5
+
+    # Wheel down with the cursor on the RIGHT half.
+    config.MASTER_VOLUME = 0.5
+    event = MagicMock()
+    event.type = pygame.MOUSEBUTTONUP
+    event.button = 5
+    event.pos = (150, 100)
+    settings_scene.handle_event(event)
+    assert config.MASTER_VOLUME < 0.5
+
+
+def test_scroll_wheel_does_not_trigger_options(settings_scene):
+    """A wheel tick over a non-volume row (e.g. Back) must do nothing."""
+    back_index = settings_scene.settings_options.index("Back")
+    rect = MagicMock()
+    rect.collidepoint.return_value = True
+    settings_scene.option_rects = [(rect, back_index)]
+
+    event = MagicMock()
+    event.type = pygame.MOUSEBUTTONUP
+    event.button = 4
+    event.pos = (100, 100)
+
+    settings_scene.handle_event(event)
+    settings_scene.game.scene_manager.switch_to.assert_not_called()
+
+
+def test_settings_layout_fits_smallest_screen(settings_scene):
+    """All option rows plus the help line must fit 800x600 without overlap."""
+    last_row_center = settings_scene.options_start_y + (len(settings_scene.settings_options) - 1) * (
+        settings_scene.option_spacing
+    )
+    # Option font is 50px tall; help text is centered at height - 50.
+    assert last_row_center + 25 < 600 - 50 - 10
 
 
 def test_escape_key_navigates_back(settings_scene):

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -43,6 +43,27 @@ class TestSceneManager:
         assert initial_game_scene is not new_game_scene
         assert isinstance(manager.current_scene, GameScene)
 
+    def test_switch_to_game_resume(self):
+        mock_game = Mock()
+        manager = SceneManager(mock_game)
+
+        # A never-entered scene is not resumable: reset=False still recreates.
+        initial_scene = manager.scenes["game"]
+        manager.switch_to("game", reset=False)
+        assert manager.scenes["game"] is not initial_scene
+
+        # An in-progress scene IS resumed by reset=False.
+        scene = manager.scenes["game"]
+        scene.mission_started = True
+        scene.mission_over = False
+        manager.switch_to("game", reset=False)
+        assert manager.scenes["game"] is scene
+
+        # A finished mission is not resumable.
+        scene.mission_over = True
+        manager.switch_to("game", reset=False)
+        assert manager.scenes["game"] is not scene
+
     def test_handle_event(self):
         mock_game = Mock()
         manager = SceneManager(mock_game)

--- a/tests/unit/test_factories_vision.py
+++ b/tests/unit/test_factories_vision.py
@@ -1,0 +1,17 @@
+from command_line_conflict import factories
+from command_line_conflict.components.vision import Vision
+
+
+def test_rover_factory_has_vision(game_state):
+    """Friendly buildings must clear their own fog of war."""
+    factory_id = factories.create_rover_factory(game_state, 10.0, 10.0, player_id=1, is_human=True)
+    vision = game_state.get_component(factory_id, Vision)
+    assert vision is not None
+    assert vision.vision_range >= 3
+
+
+def test_arachnotron_factory_has_vision(game_state):
+    factory_id = factories.create_arachnotron_factory(game_state, 10.0, 10.0, player_id=1, is_human=True)
+    vision = game_state.get_component(factory_id, Vision)
+    assert vision is not None
+    assert vision.vision_range >= 3

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -234,6 +234,122 @@ def test_research_arachnotron_at_factory(game_state):
     assert game_state.resources[1] == 20  # 120 - 100
 
 
+def test_train_chassis_refused_when_factory_surrounded(game_state):
+    """A fully surrounded factory must refuse to train (and not charge).
+
+    Regression test: the old fallback spawned the unit ON the factory tile,
+    where ProductionSystem would instantly transform it for free.
+    """
+    from command_line_conflict.scenes.game import GameScene
+
+    mock_game = MockGame()
+    scene = GameScene(mock_game)
+    scene.game_state = game_state
+    scene.current_player_id = 1
+
+    factory_id = factories.create_rover_factory(game_state, 10.0, 10.0, player_id=1, is_human=True)
+
+    # Block all 8 neighboring tiles with live units.
+    for dx in (-1, 0, 1):
+        for dy in (-1, 0, 1):
+            if dx == 0 and dy == 0:
+                continue
+            factories.create_rover(game_state, 10.0 + dx, 10.0 + dy, player_id=1, is_human=True)
+
+    game_state.resources[1] = 100
+    scene._train_chassis_at_factory(factory_id)
+
+    chassis_entities = [
+        eid
+        for eid in game_state.get_entities_with_component(UnitIdentity)
+        if game_state.get_component(eid, UnitIdentity).name == "chassis"
+    ]
+    assert len(chassis_entities) == 0
+    assert game_state.resources[1] == 100  # No charge on refusal
+
+
+def test_train_rover_refused_when_factory_surrounded(game_state):
+    """A surrounded Arachnotron Factory must not spawn a rover on its own tile.
+
+    Regression test: an on-factory rover would be transformed into a free
+    Arachnotron by ProductionSystem, bypassing the 120-scrap cost.
+    """
+    from command_line_conflict.scenes.game import GameScene
+
+    mock_game = MockGame()
+    scene = GameScene(mock_game)
+    scene.game_state = game_state
+    scene.current_player_id = 1
+
+    factory_id = factories.create_arachnotron_factory(game_state, 15.0, 15.0, player_id=1, is_human=True)
+
+    for dx in (-1, 0, 1):
+        for dy in (-1, 0, 1):
+            if dx == 0 and dy == 0:
+                continue
+            factories.create_chassis(game_state, 15.0 + dx, 15.0 + dy, player_id=1, is_human=True)
+
+    game_state.resources[1] = 100
+    scene._train_rover_at_factory(factory_id)
+
+    rovers = [
+        eid
+        for eid in game_state.get_entities_with_component(UnitIdentity)
+        if game_state.get_component(eid, UnitIdentity).name == "rover"
+    ]
+    assert len(rovers) == 0
+    assert game_state.resources[1] == 100  # No charge on refusal
+
+
+def test_r_key_fires_single_action_with_mixed_selection(game_state):
+    """With a chassis AND an Arachnotron Factory selected, one R keypress
+    must only build a Rover Factory (construction consumes the key), not
+    also train a Rover — the old behavior double-spent scrap.
+    """
+    from unittest.mock import MagicMock
+
+    import pygame
+
+    from command_line_conflict.components.selectable import Selectable
+    from command_line_conflict.scenes.game import GameScene
+
+    mock_game = MockGame()
+    scene = GameScene(mock_game)
+    scene.game_state = game_state
+    scene.current_player_id = 1
+    scene.campaign_manager = MagicMock()
+    scene.campaign_manager.is_unit_unlocked.return_value = True
+
+    chassis_id = factories.create_chassis(game_state, 10.0, 10.0, player_id=1, is_human=True)
+    game_state.get_component(chassis_id, Selectable).is_selected = True
+
+    arach_factory_id = factories.create_arachnotron_factory(game_state, 20.0, 20.0, player_id=1, is_human=True)
+    game_state.get_component(arach_factory_id, Selectable).is_selected = True
+
+    game_state.resources[1] = 1000
+
+    scene.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_r))
+
+    # The chassis was consumed to build a Rover Factory...
+    assert chassis_id not in game_state.entities
+    rover_factories = [
+        eid
+        for eid in game_state.get_entities_with_component(UnitIdentity)
+        if game_state.get_component(eid, UnitIdentity).name == "rover_factory"
+    ]
+    assert len(rover_factories) == 1
+
+    # ...and the Arachnotron Factory did NOT also train a Rover.
+    rovers = [
+        eid
+        for eid in game_state.get_entities_with_component(UnitIdentity)
+        if game_state.get_component(eid, UnitIdentity).name == "rover"
+    ]
+    assert len(rovers) == 0
+    # Only the 100-scrap factory build was charged, not 100 + 80.
+    assert game_state.resources[1] == 900
+
+
 def test_arachnotron_factory_production(game_state):
     """Verify Rover and Arachnotron training at Arachnotron Factory."""
     from command_line_conflict.scenes.game import GameScene

--- a/tmp_test/allowed/link.txt
+++ b/tmp_test/allowed/link.txt
@@ -1,1 +1,0 @@
-/app/tmp_test/secret/target.txt

--- a/tmp_test/secret/target.txt
+++ b/tmp_test/secret/target.txt
@@ -1,1 +1,0 @@
-secret content


### PR DESCRIPTION
## Description

A repository-state audit right after the scrap-economy commit (71b3554) that implemented the basic gameplay loop, plus fixes for issues found in live playtesting. Urgent bugs are fixed in code; broader deviations from the game&#39;s design are flagged with verbose, well-placed DESIGN NOTE comments instead of unilateral rewrites.

**Commit 1 — code-audit bug fixes:**
- **Campaign progression deadlock:** `rover` was only unlockable by winning mission_1, but mission_1 (FactoryBattleMap) gates the whole loop behind `is_unit_unlocked("rover")` and starts the player with three melee Chassis against ranged defenders. A fresh install could never build a Rover Factory nor plausibly win, so the unlock could never be earned. `rover` is now in `DEFAULT_UNLOCKED_UNITS`.
- **Free-upgrade exploit:** `_train_chassis_at_factory` / `_train_rover_at_factory` fell back to spawning the unit ON the factory tile when all 8 neighbors were blocked; `ProductionSystem` then instantly transformed it into the next tier at zero cost (chassis→rover; rover→arachnotron, bypassing the 120-scrap price and the adjacent-rover rule). Training now refuses — without charging — when no free adjacent tile exists (`_find_free_adjacent_tile`).
- **R/A hotkey double-fire:** with a chassis and an Arachnotron Factory both selected, one keypress triggered construction AND training (double spend). `_handle_construction` now consumes the keypress whenever a chassis is selected.
- **HUD overprint:** the chat log grew upward from `SCREEN_HEIGHT-120` straight through the Construction / Factory Production hint panels anchored at `SCREEN_HEIGHT-160`, interleaving both into unreadable text. Chat is now anchored above the hint band.
- The Arachnotron Factory panel now advertises the already-functional `C: Train Chassis (50 Scrap)` hotkey.
- In-match Arachnotron research no longer calls `save_progress()` (it never persisted `unlocked_units`; only `completed_missions` are saved) — research is now explicitly documented as session-scoped.
- Removed committed test junk `tmp_test/` (leftover from PR #371) and gitignored the directory; removed the duplicate `FogOfWar` construction in `GameScene.__init__`.

**Commit 2 — playtest fixes (verified by driving the game headlessly with real pygame events):**
- **Settings screen layout:** the 7 option rows overflowed 800x600 — "Mute Audio" overprinted the help tooltip and "Back" was cut off. Rows now fit above the help line.
- **Settings scroll wheel:** wheel ticks are legacy button-4/5 clicks; the handler treated any button as a click, so scrolling adjusted volume based on cursor *position* (up and down did the same thing) and a wheel tick over "Back" exited the menu. Wheel direction is now static (up = +10%, down = −10%), the wheel is inert on non-volume rows, and only left-click activates options.
- **Continue Campaign resumes the match:** `switch_to("game")` unconditionally recreated `GameScene`, discarding an ESC&#39;d game. ESC now freezes the scene and `switch_to("game", reset=False)` returns to it; the menu shows "Continue Campaign" whenever a resumable match exists (even with zero completed missions). Finished missions are not resumable.
- **Building vision:** factories now carry `Vision(4)` — a player&#39;s own base previously sat inside fog of war.
- **Chat flood:** notifications use a dedicated smaller font, consecutive duplicates collapse into one counted line ("Insufficient scrap! … (x4)"), and the transient overlay caps at 6 lines (full history remains on the `L` log toggle).

**Design conflicts flagged with comments only (no behavior change):**
- `ProductionSystem`: free walk-in transformation coexists with paid hotkey training, so every scrap price can be sidestepped by right-clicking a unit onto a factory tile; three reconciliation options are documented in the class docstring.
- `campaign_manager.MISSION_REWARDS`: two competing tech systems (persistent campaign rewards vs session-scoped in-match research), with guidance for extending either.
- `ResourceSystem`: wildlife-kill drip is the only income and doesn&#39;t scale with player investment; the default-unlocked `extractor` unit has no economic role despite its name.

A `.jules/fable.md` journal entry records the full audit per repo convention.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `rover` is now unlocked on fresh saves and `Continue Campaign` resumes in-progress matches, so `test_initial_state`, `test_menu_trigger_continue`, and the settings mouse tests were updated to the new behavior; existing saves are unaffected.
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (263 passed, coverage 80.84%, flake8/mypy clean, pylint 9.82)
- [ ] Any dependent changes have been merged and published in downstream modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rRy36QwmeFS1fH5b4zvmW