### PR TITLE
Add RTS control group hotkeys (1-9, 0)

### DIFF
--- a/command_line_conflict/config.py
+++ b/command_line_conflict/config.py
@@ -22,6 +22,12 @@ FPS = 60
 # The speed of the camera movement.
 CAMERA_SPEED = 10
 
+# Number of RTS-style control groups available to the player (hotkeys 1-9, 0).
+NUM_CONTROL_GROUPS = 10
+# Maximum interval (ms) between two control-group key presses that counts as a
+# double-press, which snaps the camera to that group.
+CONTROL_GROUP_DOUBLE_TAP_MS = 400
+
 # A dictionary mapping player IDs to their colors.
 PLAYER_COLORS = {
     0: (128, 128, 128),  # Grey (Neutral)

--- a/command_line_conflict/scenes/game.py
+++ b/command_line_conflict/scenes/game.py
@@ -23,6 +23,7 @@ from command_line_conflict.systems.ai_system import AISystem
 from command_line_conflict.systems.chat_system import ChatSystem
 from command_line_conflict.systems.combat_system import CombatSystem
 from command_line_conflict.systems.confetti_system import ConfettiSystem
+from command_line_conflict.systems.control_group_system import ControlGroupSystem
 from command_line_conflict.systems.corpse_removal_system import CorpseRemovalSystem
 from command_line_conflict.systems.flee_system import FleeSystem
 from command_line_conflict.systems.health_system import HealthSystem
@@ -44,6 +45,33 @@ class UnitView:
         self.x = x
         self.y = y
         self.vision_range = vision_range
+
+
+# Maps number-row keys to control group numbers. K_0 is bound to the 10th
+# group (matching the classic RTS convention of "1-9, 0").
+NUMBER_KEY_TO_GROUP = {
+    pygame.K_1: 1,
+    pygame.K_2: 2,
+    pygame.K_3: 3,
+    pygame.K_4: 4,
+    pygame.K_5: 5,
+    pygame.K_6: 6,
+    pygame.K_7: 7,
+    pygame.K_8: 8,
+    pygame.K_9: 9,
+    pygame.K_0: 10,
+}
+
+# Debug-only unit spawning, kept off the plain number/Ctrl+number keys so it
+# doesn't collide with control-group hotkeys (see _handle_control_group_key).
+DEBUG_SPAWN_KEYS = {
+    pygame.K_1: factories.create_extractor,
+    pygame.K_2: factories.create_chassis,
+    pygame.K_3: factories.create_rover,
+    pygame.K_4: factories.create_arachnotron,
+    pygame.K_5: factories.create_observer,
+    pygame.K_6: factories.create_immortal,
+}
 
 
 class GameScene:
@@ -91,6 +119,12 @@ class GameScene:
         self.hovered_entity_id = None
         self._wave_cache = {}
 
+        # Control groups (hotkeys 1-9, 0). Tracks the last press time (ms) per
+        # group number so a quick second press can be detected as a
+        # double-tap and snap the camera to that group.
+        self.control_group_system = ControlGroupSystem()
+        self._last_group_key_time: dict[int, int] = {}
+
         # Initialize systems
         self.campaign_manager = CampaignManager()
         self.game_state.campaign_manager = self.campaign_manager
@@ -132,7 +166,7 @@ class GameScene:
                 "F1: Toggle Reveal Map",
                 "F2: Toggle God Mode",
                 "TAB: Switch Player",
-                "1-6: Spawn Units",
+                "Ctrl+Shift+1-6: Spawn Units",
             ]
             for cheat in cheats_list:
                 log.info(cheat)
@@ -282,82 +316,40 @@ class GameScene:
                 self.camera_movement["left"] = True
             elif event.key == pygame.K_RIGHT:
                 self.camera_movement["right"] = True
+            elif event.key in NUMBER_KEY_TO_GROUP:
+                mods = pygame.key.get_mods()
+                # Debug-only unit spawning shares the number row but requires
+                # Ctrl+Shift, so plain Ctrl+number stays free for assigning
+                # control groups even when config.DEBUG is on.
+                if config.DEBUG and mods & pygame.KMOD_CTRL and mods & pygame.KMOD_SHIFT:
+                    mx, my = pygame.mouse.get_pos()
+                    gx, gy = self.camera.screen_to_grid(mx, my)
+                    spawn_fn = DEBUG_SPAWN_KEYS.get(event.key)
+                    if spawn_fn:
+                        spawn_fn(self.game_state, gx, gy, player_id=self.current_player_id, is_human=True)
+                else:
+                    self._handle_control_group_key(event.key, mods)
             else:
                 if config.DEBUG:
-                    mods = pygame.key.get_mods()
-                    if mods & pygame.KMOD_CTRL:
-                        mx, my = pygame.mouse.get_pos()
-                        gx, gy = self.camera.screen_to_grid(mx, my)
-                        if event.key == pygame.K_1:
-                            factories.create_extractor(
-                                self.game_state,
-                                gx,
-                                gy,
-                                player_id=self.current_player_id,
-                                is_human=True,
-                            )
-                        elif event.key == pygame.K_2:
-                            factories.create_chassis(
-                                self.game_state,
-                                gx,
-                                gy,
-                                player_id=self.current_player_id,
-                                is_human=True,
-                            )
-                        elif event.key == pygame.K_3:
-                            factories.create_rover(
-                                self.game_state,
-                                gx,
-                                gy,
-                                player_id=self.current_player_id,
-                                is_human=True,
-                            )
-                        elif event.key == pygame.K_4:
-                            factories.create_arachnotron(
-                                self.game_state,
-                                gx,
-                                gy,
-                                player_id=self.current_player_id,
-                                is_human=True,
-                            )
-                        elif event.key == pygame.K_5:
-                            factories.create_observer(
-                                self.game_state,
-                                gx,
-                                gy,
-                                player_id=self.current_player_id,
-                                is_human=True,
-                            )
-                        elif event.key == pygame.K_6:
-                            factories.create_immortal(
-                                self.game_state,
-                                gx,
-                                gy,
-                                player_id=self.current_player_id,
-                                is_human=True,
-                            )
-
-                    # Debug cheats
-                    if config.DEBUG:
-                        if event.key == pygame.K_F1:
-                            self.cheats["reveal_map"] = not self.cheats["reveal_map"]
-                            status = "Enabled" if self.cheats["reveal_map"] else "Disabled"
-                            log.info(f"Cheat 'Reveal Map' toggled: {self.cheats['reveal_map']}")
-                            self.chat_system.add_message(f"Cheat: Map Reveal {status}", (255, 0, 255))
-                        elif event.key == pygame.K_F2:
-                            self.cheats["god_mode"] = not self.cheats["god_mode"]
-                            status = "Enabled" if self.cheats["god_mode"] else "Disabled"
-                            log.info(f"Cheat 'God Mode' toggled: {self.cheats['god_mode']}")
-                            self.chat_system.add_message(f"Cheat: God Mode {status}", (255, 0, 255))
-                        elif event.key == pygame.K_TAB:
-                            # Security: Gated side-switching feature behind config.DEBUG to prevent unauthorized access
-                            self.selection_system.clear_selection(self.game_state)
-                            if self.current_player_id == 1:
-                                self.current_player_id = 2
-                            else:
-                                self.current_player_id = 1
-                            log.info(f"Switched to player {self.current_player_id}")
-                            self.chat_system.add_message(f"Switched to player {self.current_player_id}", (255, 0, 255))
+                    if event.key == pygame.K_F1:
+                        self.cheats["reveal_map"] = not self.cheats["reveal_map"]
+                        status = "Enabled" if self.cheats["reveal_map"] else "Disabled"
+                        log.info(f"Cheat 'Reveal Map' toggled: {self.cheats['reveal_map']}")
+                        self.chat_system.add_message(f"Cheat: Map Reveal {status}", (255, 0, 255))
+                    elif event.key == pygame.K_F2:
+                        self.cheats["god_mode"] = not self.cheats["god_mode"]
+                        status = "Enabled" if self.cheats["god_mode"] else "Disabled"
+                        log.info(f"Cheat 'God Mode' toggled: {self.cheats['god_mode']}")
+                        self.chat_system.add_message(f"Cheat: God Mode {status}", (255, 0, 255))
+                    elif event.key == pygame.K_TAB:
+                        # Security: Gated side-switching feature behind config.DEBUG to prevent unauthorized access
+                        self.selection_system.clear_selection(self.game_state)
+                        if self.current_player_id == 1:
+                            self.current_player_id = 2
+                        else:
+                            self.current_player_id = 1
+                        log.info(f"Switched to player {self.current_player_id}")
+                        self.chat_system.add_message(f"Switched to player {self.current_player_id}", (255, 0, 255))
 
                 if event.key == pygame.K_c:
                     selected_factories = []
@@ -527,6 +519,52 @@ class GameScene:
 
         if not cursor_set:
             pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_ARROW)
+
+    def _handle_control_group_key(self, key: int, mods: int) -> None:
+        """Handles a control-group hotkey (number row keys 1-9 and 0).
+
+        Ctrl+<number> assigns the current selection to the group. A plain
+        <number> press recalls it; pressing the same group's key twice within
+        config.CONTROL_GROUP_DOUBLE_TAP_MS also snaps the camera to it.
+        """
+        group_number = NUMBER_KEY_TO_GROUP[key]
+
+        if mods & pygame.KMOD_CTRL:
+            assigned = self.control_group_system.assign_group(self.game_state, group_number, self.current_player_id)
+            if assigned:
+                log.info(f"Control group {group_number} assigned ({len(assigned)} entities)")
+                self.chat_system.add_message(f"Control group {group_number} assigned", (255, 255, 0))
+            return
+
+        entity_ids = self.control_group_system.select_group(self.game_state, group_number, self.current_player_id)
+        if not entity_ids:
+            return
+
+        self.game_state.add_event({"type": "sound", "data": {"name": "click_select"}})
+
+        now = pygame.time.get_ticks()
+        last_press = self._last_group_key_time.get(group_number)
+        self._last_group_key_time[group_number] = now
+
+        if last_press is not None and now - last_press <= config.CONTROL_GROUP_DOUBLE_TAP_MS:
+            self._center_camera_on_group(entity_ids)
+
+    def _center_camera_on_group(self, entity_ids: list) -> None:
+        """Snaps the camera so its viewport is centered on a group's average position."""
+        center = self.control_group_system.get_center_position(self.game_state, entity_ids)
+        if center is None or self.game.screen is None:
+            return
+
+        grid_size = config.GRID_SIZE * self.camera.zoom
+        if grid_size <= 0:
+            return
+
+        screen_width, screen_height = self.game.screen.get_size()
+        cx, cy = center
+        self.camera.set_position(
+            cx - (screen_width / grid_size) / 2,
+            cy - (screen_height / grid_size) / 2,
+        )
 
     def _handle_construction(self, key) -> bool:
         """Handles building construction requests.

--- a/command_line_conflict/systems/control_group_system.py
+++ b/command_line_conflict/systems/control_group_system.py
@@ -1,0 +1,134 @@
+from ..components.dead import Dead
+from ..components.movable import Movable
+from ..components.player import Player
+from ..components.position import Position
+from ..components.selectable import Selectable
+from ..game_state import GameState
+from ..logger import log
+
+
+class ControlGroupSystem:
+    """Manages numbered control groups of selected entities (RTS-style hotkeys).
+
+    Conventions mirrored from genre staples like StarCraft:
+      - Ctrl+<number> assigns the current selection to a control group,
+        replacing whatever was previously bound to that number.
+      - <number> alone recalls a group, replacing the current selection.
+      - A group may hold any number of units, but at most one building
+        (a stationary, non-Movable entity such as a factory). Assigning a
+        selection containing several buildings keeps only the first one.
+    """
+
+    def __init__(self) -> None:
+        # player_id -> {group_number: set(entity_id)}
+        self._groups: dict[int, dict[int, set[int]]] = {}
+
+    @staticmethod
+    def _is_building(components: dict) -> bool:
+        """Stationary (non-Movable) entities are treated as buildings."""
+        return Movable not in components
+
+    def assign_group(self, game_state: GameState, group_number: int, player_id: int) -> set[int]:
+        """Binds the current selection (owned by player_id) to a control group.
+
+        Returns:
+            The set of entity IDs actually assigned to the group (empty if
+            nothing was selected).
+        """
+        selected = []
+        for entity_id in game_state.get_entities_with_component(Selectable):
+            components = game_state.entities.get(entity_id)
+            if not components:
+                continue
+
+            selectable = components.get(Selectable)
+            player = components.get(Player)
+            if selectable and selectable.is_selected and player and player.player_id == player_id:
+                selected.append((entity_id, components))
+
+        group: set[int] = set()
+        building_assigned = False
+        skipped_buildings = 0
+        for entity_id, components in selected:
+            if self._is_building(components):
+                if building_assigned:
+                    skipped_buildings += 1
+                    continue
+                building_assigned = True
+            group.add(entity_id)
+
+        if not group:
+            return group
+
+        self._groups.setdefault(player_id, {})[group_number] = group
+        log.debug(f"Player {player_id} assigned {len(group)} entities to control group {group_number}")
+        if skipped_buildings:
+            log.debug(f"Control group {group_number}: only one building allowed, skipped {skipped_buildings}")
+
+        return group
+
+    def get_group_entities(self, game_state: GameState, group_number: int, player_id: int) -> list[int]:
+        """Returns the still-alive entity IDs bound to a group, pruning any that are gone."""
+        player_groups = self._groups.get(player_id)
+        if not player_groups or group_number not in player_groups:
+            return []
+
+        bound_ids = player_groups[group_number]
+        alive_ids = []
+        stale_ids = []
+        for entity_id in bound_ids:
+            components = game_state.entities.get(entity_id)
+            if not components or components.get(Dead) or not components.get(Selectable):
+                stale_ids.append(entity_id)
+                continue
+            alive_ids.append(entity_id)
+
+        if stale_ids:
+            bound_ids.difference_update(stale_ids)
+
+        return alive_ids
+
+    def select_group(self, game_state: GameState, group_number: int, player_id: int) -> list[int]:
+        """Selects every entity bound to a group, replacing the current selection.
+
+        Returns:
+            The entity IDs newly selected (empty if the group has no members).
+        """
+        entity_ids = self.get_group_entities(game_state, group_number, player_id)
+        if not entity_ids:
+            return entity_ids
+
+        target_ids = set(entity_ids)
+        for entity_id in game_state.get_entities_with_component(Selectable):
+            components = game_state.entities.get(entity_id)
+            if not components:
+                continue
+
+            player = components.get(Player)
+            if not player or player.player_id != player_id:
+                continue
+
+            selectable = components.get(Selectable)
+            if selectable:
+                selectable.is_selected = entity_id in target_ids
+
+        log.debug(f"Player {player_id} selected control group {group_number} ({len(entity_ids)} entities)")
+        return entity_ids
+
+    @staticmethod
+    def get_center_position(game_state: GameState, entity_ids: list[int]) -> "tuple[float, float] | None":
+        """Returns the centroid (x, y) of the given entities' positions, or None if none have one."""
+        total_x = 0.0
+        total_y = 0.0
+        count = 0
+        for entity_id in entity_ids:
+            position = game_state.get_component(entity_id, Position)
+            if position:
+                total_x += position.x
+                total_y += position.y
+                count += 1
+
+        if count == 0:
+            return None
+
+        return total_x / count, total_y / count

--- a/tests/unit/scenes/test_game_scene_control_groups.py
+++ b/tests/unit/scenes/test_game_scene_control_groups.py
@@ -1,0 +1,175 @@
+from unittest.mock import MagicMock
+
+import pygame
+
+from command_line_conflict import config
+from command_line_conflict.components.factory import Factory
+from command_line_conflict.components.movable import Movable
+from command_line_conflict.components.player import Player
+from command_line_conflict.components.position import Position
+from command_line_conflict.components.selectable import Selectable
+from command_line_conflict.scenes.game import NUMBER_KEY_TO_GROUP, GameScene
+
+
+class MockGame:
+    def __init__(self):
+        self.screen = MagicMock()
+        self.screen.get_size.return_value = (800, 600)
+        self.font = MagicMock()
+        self.music_manager = MagicMock()
+        self.scene_manager = MagicMock()
+        self.steam = MagicMock()
+
+
+def _keydown(key):
+    return pygame.event.Event(pygame.KEYDOWN, {"key": key})
+
+
+def _make_selected_unit(game_state, x, y, player_id=1):
+    entity_id = game_state.create_entity()
+    game_state.add_component(entity_id, Position(x, y))
+    game_state.add_component(entity_id, Movable(speed=1.0))
+    game_state.add_component(entity_id, Selectable())
+    game_state.add_component(entity_id, Player(player_id=player_id, is_human=True))
+    game_state.entities[entity_id][Selectable].is_selected = True
+    return entity_id
+
+
+def _make_selected_building(game_state, x, y, player_id=1):
+    entity_id = game_state.create_entity()
+    game_state.add_component(entity_id, Position(x, y))
+    game_state.add_component(entity_id, Factory(input_unit="chassis", output_unit="rover"))
+    game_state.add_component(entity_id, Selectable())
+    game_state.add_component(entity_id, Player(player_id=player_id, is_human=True))
+    game_state.entities[entity_id][Selectable].is_selected = True
+    return entity_id
+
+
+def test_at_least_ten_control_groups_are_addressable():
+    # 1-9 and 0 (bound to the 10th group) must all be distinct group numbers.
+    assert len(NUMBER_KEY_TO_GROUP) >= 10
+    assert len(set(NUMBER_KEY_TO_GROUP.values())) >= 10
+    assert NUMBER_KEY_TO_GROUP[pygame.K_0] == 10
+
+
+def test_ctrl_number_assigns_selection_to_group(mocker):
+    game = MockGame()
+    scene = GameScene(game)
+    game_state = scene.game_state
+    unit_id = _make_selected_unit(game_state, 3, 3)
+
+    mocker.patch("pygame.key.get_mods", return_value=pygame.KMOD_CTRL)
+    scene.handle_event(_keydown(pygame.K_1))
+
+    assert scene.control_group_system.select_group(game_state, 1, scene.current_player_id) == [unit_id]
+
+
+def test_number_alone_recalls_group_selection(mocker):
+    game = MockGame()
+    scene = GameScene(game)
+    game_state = scene.game_state
+    unit_id = _make_selected_unit(game_state, 3, 3)
+
+    mocker.patch("pygame.key.get_mods", return_value=pygame.KMOD_CTRL)
+    scene.handle_event(_keydown(pygame.K_1))
+
+    # Deselect, then recall via a plain (no-Ctrl) press of the same key.
+    game_state.entities[unit_id][Selectable].is_selected = False
+    mocker.patch("pygame.key.get_mods", return_value=0)
+    scene.handle_event(_keydown(pygame.K_1))
+
+    assert game_state.entities[unit_id][Selectable].is_selected is True
+
+
+def test_only_one_building_survives_group_assignment(mocker):
+    game = MockGame()
+    scene = GameScene(game)
+    game_state = scene.game_state
+    building_a = _make_selected_building(game_state, 0, 0)
+    building_b = _make_selected_building(game_state, 1, 1)
+    unit_id = _make_selected_unit(game_state, 2, 2)
+
+    mocker.patch("pygame.key.get_mods", return_value=pygame.KMOD_CTRL)
+    scene.handle_event(_keydown(pygame.K_2))
+
+    group = scene.control_group_system.select_group(game_state, 2, scene.current_player_id)
+    assert unit_id in group
+    assert building_a in group
+    assert building_b not in group
+    assert len(group) == 2
+
+
+def test_double_tap_group_key_centers_camera(mocker):
+    game = MockGame()
+    scene = GameScene(game)
+    game_state = scene.game_state
+    _make_selected_unit(game_state, 30, 40)
+
+    mocker.patch("pygame.key.get_mods", return_value=pygame.KMOD_CTRL)
+    scene.handle_event(_keydown(pygame.K_3))
+
+    mocker.patch("pygame.key.get_mods", return_value=0)
+    mocker.patch("pygame.time.get_ticks", return_value=1000)
+    scene.handle_event(_keydown(pygame.K_3))  # first recall: no snap yet
+    initial_camera_x = scene.camera.x
+    initial_camera_y = scene.camera.y
+
+    mocker.patch("pygame.time.get_ticks", return_value=1000 + config.CONTROL_GROUP_DOUBLE_TAP_MS - 1)
+    scene.handle_event(_keydown(pygame.K_3))  # second recall within the window: snap
+
+    grid_size = config.GRID_SIZE * scene.camera.zoom
+    screen_w, screen_h = game.screen.get_size()
+    assert scene.camera.x != initial_camera_x
+    assert scene.camera.x == 30 - (screen_w / grid_size) / 2
+    assert scene.camera.y == 40 - (screen_h / grid_size) / 2
+    assert initial_camera_y == 0  # sanity: camera really did start at the default origin
+
+
+def test_slow_second_press_does_not_center_camera(mocker):
+    game = MockGame()
+    scene = GameScene(game)
+    game_state = scene.game_state
+    _make_selected_unit(game_state, 30, 40)
+
+    mocker.patch("pygame.key.get_mods", return_value=pygame.KMOD_CTRL)
+    scene.handle_event(_keydown(pygame.K_4))
+
+    mocker.patch("pygame.key.get_mods", return_value=0)
+    mocker.patch("pygame.time.get_ticks", return_value=1000)
+    scene.handle_event(_keydown(pygame.K_4))
+
+    mocker.patch("pygame.time.get_ticks", return_value=1000 + config.CONTROL_GROUP_DOUBLE_TAP_MS + 1)
+    scene.handle_event(_keydown(pygame.K_4))
+
+    assert scene.camera.x == 0
+    assert scene.camera.y == 0
+
+
+def test_debug_ctrl_shift_number_spawns_unit_instead_of_assigning_group(mocker):
+    mocker.patch("command_line_conflict.config.DEBUG", True)
+    game = MockGame()
+    scene = GameScene(game)
+    game_state = scene.game_state
+
+    mocker.patch("pygame.mouse.get_pos", return_value=(40, 40))
+    mocker.patch("pygame.key.get_mods", return_value=pygame.KMOD_CTRL | pygame.KMOD_SHIFT)
+
+    entity_count_before = len(game_state.entities)
+    scene.handle_event(_keydown(pygame.K_2))  # Ctrl+Shift+2 -> debug-spawn a chassis
+
+    assert len(game_state.entities) == entity_count_before + 1
+    # Nothing should have been bound to control group 2 by this spawn shortcut.
+    assert not scene.control_group_system.select_group(game_state, 2, scene.current_player_id)
+
+
+def test_plain_ctrl_number_still_assigns_group_in_debug_mode(mocker):
+    mocker.patch("command_line_conflict.config.DEBUG", True)
+    game = MockGame()
+    scene = GameScene(game)
+    game_state = scene.game_state
+    unit_id = _make_selected_unit(game_state, 5, 5)
+
+    mocker.patch("pygame.key.get_mods", return_value=pygame.KMOD_CTRL)
+    scene.handle_event(_keydown(pygame.K_5))
+
+    assert scene.control_group_system.select_group(game_state, 5, scene.current_player_id) == [unit_id]

--- a/tests/unit/systems/test_control_group_system.py
+++ b/tests/unit/systems/test_control_group_system.py
@@ -1,0 +1,157 @@
+from command_line_conflict.components.dead import Dead
+from command_line_conflict.components.factory import Factory
+from command_line_conflict.components.movable import Movable
+from command_line_conflict.components.player import Player
+from command_line_conflict.components.position import Position
+from command_line_conflict.components.selectable import Selectable
+from command_line_conflict.game_state import GameState
+from command_line_conflict.maps.simple_map import SimpleMap
+from command_line_conflict.systems.control_group_system import ControlGroupSystem
+
+
+def make_unit(game_state: GameState, x: float, y: float, player_id: int = 1, selected: bool = True) -> int:
+    """Creates a mobile, selectable "unit" (has Movable)."""
+    entity_id = game_state.create_entity()
+    game_state.add_component(entity_id, Position(x, y))
+    game_state.add_component(entity_id, Movable(speed=1.0))
+    game_state.add_component(entity_id, Selectable())
+    game_state.add_component(entity_id, Player(player_id=player_id))
+    game_state.entities[entity_id][Selectable].is_selected = selected
+    return entity_id
+
+
+def make_building(game_state: GameState, x: float, y: float, player_id: int = 1, selected: bool = True) -> int:
+    """Creates a stationary, selectable "building" (no Movable)."""
+    entity_id = game_state.create_entity()
+    game_state.add_component(entity_id, Position(x, y))
+    game_state.add_component(entity_id, Factory(input_unit="chassis", output_unit="rover"))
+    game_state.add_component(entity_id, Selectable())
+    game_state.add_component(entity_id, Player(player_id=player_id))
+    game_state.entities[entity_id][Selectable].is_selected = selected
+    return entity_id
+
+
+def make_state() -> GameState:
+    return GameState(SimpleMap())
+
+
+def test_assign_and_select_group_round_trip():
+    game_state = make_state()
+    system = ControlGroupSystem()
+    unit_a = make_unit(game_state, 0, 0)
+    unit_b = make_unit(game_state, 2, 2)
+
+    assigned = system.assign_group(game_state, 1, player_id=1)
+    assert assigned == {unit_a, unit_b}
+
+    # Deselect everything, then recall the group.
+    game_state.entities[unit_a][Selectable].is_selected = False
+    game_state.entities[unit_b][Selectable].is_selected = False
+
+    selected = system.select_group(game_state, 1, player_id=1)
+    assert set(selected) == {unit_a, unit_b}
+    assert game_state.entities[unit_a][Selectable].is_selected is True
+    assert game_state.entities[unit_b][Selectable].is_selected is True
+
+
+def test_assigning_empty_selection_assigns_nothing():
+    game_state = make_state()
+    system = ControlGroupSystem()
+    make_unit(game_state, 0, 0, selected=False)
+
+    assigned = system.assign_group(game_state, 1, player_id=1)
+    assert assigned == set()
+    assert not system.select_group(game_state, 1, player_id=1)
+
+
+def test_at_least_ten_group_slots_are_independent():
+    game_state = make_state()
+    system = ControlGroupSystem()
+
+    entity_ids = []
+    for i in range(10):
+        eid = make_unit(game_state, i, i, selected=True)
+        entity_ids.append(eid)
+        assigned = system.assign_group(game_state, i + 1, player_id=1)
+        assert assigned == {eid}
+        game_state.entities[eid][Selectable].is_selected = False
+
+    for i in range(10):
+        selected = system.select_group(game_state, i + 1, player_id=1)
+        assert selected == [entity_ids[i]]
+        game_state.entities[entity_ids[i]][Selectable].is_selected = False
+
+
+def test_selecting_group_replaces_current_selection():
+    game_state = make_state()
+    system = ControlGroupSystem()
+    grouped = make_unit(game_state, 0, 0, selected=True)
+    system.assign_group(game_state, 1, player_id=1)
+
+    other = make_unit(game_state, 5, 5, selected=True)
+    game_state.entities[grouped][Selectable].is_selected = False
+
+    system.select_group(game_state, 1, player_id=1)
+
+    assert game_state.entities[grouped][Selectable].is_selected is True
+    assert game_state.entities[other][Selectable].is_selected is False
+
+
+def test_only_one_building_allowed_per_group():
+    game_state = make_state()
+    system = ControlGroupSystem()
+    building_1 = make_building(game_state, 0, 0)
+    building_2 = make_building(game_state, 1, 1)
+    unit = make_unit(game_state, 2, 2)
+
+    assigned = system.assign_group(game_state, 1, player_id=1)
+
+    assert unit in assigned
+    assert building_1 in assigned
+    assert building_2 not in assigned
+    assert len(assigned) == 2
+
+
+def test_group_is_scoped_to_a_single_player():
+    game_state = make_state()
+    system = ControlGroupSystem()
+    p1_unit = make_unit(game_state, 0, 0, player_id=1, selected=True)
+    make_unit(game_state, 1, 1, player_id=2, selected=True)
+
+    assigned = system.assign_group(game_state, 1, player_id=1)
+    assert assigned == {p1_unit}
+
+    # Player 2 has nothing bound to group 1.
+    assert not system.select_group(game_state, 1, player_id=2)
+
+
+def test_dead_or_removed_entities_are_pruned_from_group():
+    game_state = make_state()
+    system = ControlGroupSystem()
+    alive = make_unit(game_state, 0, 0)
+    dying = make_unit(game_state, 1, 1)
+    removed = make_unit(game_state, 2, 2)
+
+    system.assign_group(game_state, 1, player_id=1)
+
+    game_state.add_component(dying, Dead())
+    game_state.remove_entity(removed)
+
+    selected = system.select_group(game_state, 1, player_id=1)
+    assert selected == [alive]
+
+
+def test_get_center_position_returns_centroid():
+    game_state = make_state()
+    system = ControlGroupSystem()
+    a = make_unit(game_state, 0, 0)
+    b = make_unit(game_state, 4, 2)
+
+    center = system.get_center_position(game_state, [a, b])
+    assert center == (2.0, 1.0)
+
+
+def test_get_center_position_returns_none_when_no_positions():
+    game_state = make_state()
+    system = ControlGroupSystem()
+    assert system.get_center_position(game_state, []) is None


### PR DESCRIPTION
## Description

Implements RTS-style control group hotkeys, a core genre convention that was missing:

- **10 control groups** are available via the number row: `1`-`9` plus `0` bound to the 10th group.
- **Ctrl+&lt;number&gt;** assigns the current selection to a control group, replacing whatever was previously bound to it.
- **&lt;number&gt;** alone recalls a group, replacing the current selection.
- **Double-tapping** the same group key within `config.CONTROL_GROUP_DOUBLE_TAP_MS` (400ms) snaps the camera to the group's average position, in addition to selecting it.
- A group may hold any number of units, but **at most one building** (a stationary, non-`Movable` entity). Assigning a selection with several buildings keeps only the first and drops the rest.

New `ControlGroupSystem` (`command_line_conflict/systems/control_group_system.py`) owns per-player group state and is wired into `GameScene.handle_event`. To avoid a keybinding collision, the existing debug-only unit-spawn cheat (`config.DEBUG` only) was moved from `Ctrl+<number>` to `Ctrl+Shift+<number>`, so plain `Ctrl+<number>` is always available for control groups.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project (black, isort, flake8, pylint all clean)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (280 passed, 81.55% coverage)
- [x] Any dependent changes have been merged and published in downstream modules

## Test plan

- `python -m pytest` — full suite passes (280 tests)
- New unit tests: `tests/unit/systems/test_control_group_system.py` (assign/select round-trip, 10 independent slots, one-building cap, per-player scoping, stale-entity pruning, centroid math)
- New scene-level tests: `tests/unit/scenes/test_game_scene_control_groups.py` (Ctrl+number assignment, plain-number recall, one-building cap through `handle_event`, double-tap camera centering vs. a slow second press, and the debug Ctrl+Shift+number spawn no longer colliding with control groups)


---
_Generated by [Claude Code](https://claude.ai/code/session_01S42ickdou99sZbiWEFXgd2)_