### PR TITLE
🎨 Palette: Add tooltip for disabled file dialog action button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -95,3 +95,7 @@
 ## 2026-05-25 - Rapid Pagination Support in FileDialog
 **Learning:** For scrollable lists that can grow significantly (like save files or levels), standard arrow-key navigation (up/down one item at a time) becomes tedious and a barrier to efficient keyboard navigation.
 **Action:** When implementing or enhancing scrollable UI components, always support rapid pagination using `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN`. Calculate the pagination jump size logically based on the visible view bounds (e.g., jump by `max_visible_files`) and ensure helper text is updated to clearly communicate this capability to the user.
+
+## 2024-07-10 - FileDialog Disabled State Feedback
+**Learning:** The FileDialog's action buttons (Save/Load) silently appear disabled without contextual feedback when no filename is provided, leaving users guessing. This pattern is specific to how custom Pygame UI elements handle interaction states in this app.
+**Action:** Always implement a contextual tooltip with a semi-transparent background near disabled interactive elements on hover (e.g., explaining "Filename required") to clarify the expected system state and improve discoverability.

--- a/command_line_conflict/ui/file_dialog.py
+++ b/command_line_conflict/ui/file_dialog.py
@@ -324,3 +324,16 @@ class FileDialog:
         btn_text_color = (255, 255, 255) if action_enabled else (200, 200, 200)
         btn_surf = self.font.render(btn_text, True, btn_text_color)
         self.screen.blit(btn_surf, (self.action_button_rect.x + 10, self.action_button_rect.y + 5))
+
+        if not action_enabled and self.hovered_element == "action":
+            tooltip_text = "Filename required"
+            tooltip_size = self.font.size(tooltip_text)
+            tooltip_surf = pygame.Surface((tooltip_size[0] + 10, tooltip_size[1] + 10), pygame.SRCALPHA)
+            tooltip_surf.fill((0, 0, 0, 200))
+
+            text_surf = self.font.render(tooltip_text, True, (255, 255, 255))
+            tooltip_surf.blit(text_surf, (5, 5))
+
+            tooltip_x = self.action_button_rect.x - tooltip_size[0] - 15
+            tooltip_y = self.action_button_rect.y + (self.action_button_rect.height - tooltip_size[1]) // 2 - 5
+            self.screen.blit(tooltip_surf, (tooltip_x, tooltip_y))

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,26 @@
+<<<<<<< SEARCH
+        pygame.draw.rect(self.screen, action_color, self.action_button_rect)
+        btn_text = "Save" if self.mode == "save" else "Load"
+        btn_text_color = (255, 255, 255) if action_enabled else (200, 200, 200)
+        btn_surf = self.font.render(btn_text, True, btn_text_color)
+        self.screen.blit(btn_surf, (self.action_button_rect.x + 10, self.action_button_rect.y + 5))
+=======
+        pygame.draw.rect(self.screen, action_color, self.action_button_rect)
+        btn_text = "Save" if self.mode == "save" else "Load"
+        btn_text_color = (255, 255, 255) if action_enabled else (200, 200, 200)
+        btn_surf = self.font.render(btn_text, True, btn_text_color)
+        self.screen.blit(btn_surf, (self.action_button_rect.x + 10, self.action_button_rect.y + 5))
+
+        if not action_enabled and self.hovered_element == "action":
+            tooltip_text = "Filename required"
+            tooltip_size = self.font.size(tooltip_text)
+            tooltip_surf = pygame.Surface((tooltip_size[0] + 10, tooltip_size[1] + 10), pygame.SRCALPHA)
+            tooltip_surf.fill((0, 0, 0, 200))
+
+            text_surf = self.font.render(tooltip_text, True, (255, 255, 255))
+            tooltip_surf.blit(text_surf, (5, 5))
+
+            tooltip_x = self.action_button_rect.x - tooltip_size[0] - 15
+            tooltip_y = self.action_button_rect.y + (self.action_button_rect.height - tooltip_size[1]) // 2 - 5
+            self.screen.blit(tooltip_surf, (tooltip_x, tooltip_y))
+>>>>>>> REPLACE


### PR DESCRIPTION
**💡 What:** Added a contextual tooltip for the disabled action button in the FileDialog.
**🎯 Why:** The Save/Load action button silently appears disabled without contextual feedback when no filename is provided, leaving users guessing. This pattern was identified as an accessibility and usability issue specific to the custom Pygame UI elements in this app.
**📸 Before/After:** Before, the button was grayed out with no explanation. After, hovering the button displays a semi-transparent tooltip saying "Filename required".
**♿ Accessibility:** Improves discoverability and user feedback for disabled interactive elements, clarifying the expected system state without requiring guesswork.

---
*PR created automatically by Jules for task [8903589669948234227](https://jules.google.com/task/8903589669948234227) started by @tsainez*