### PR TITLE
🧹 Remove unused __future__ import in factory_battle_map

### DIFF
--- a/command_line_conflict/maps/factory_battle_map.py
+++ b/command_line_conflict/maps/factory_battle_map.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import TYPE_CHECKING
 
 from .base import Map


### PR DESCRIPTION
🎯 **What:** Removed an unused `from __future__ import annotations` statement and the trailing blank line from `command_line_conflict/maps/factory_battle_map.py`.
💡 **Why:** This import is unreferenced by the file's current code. Removing it cleans up dead code and improves readability by reducing clutter at the top of the file.
✅ **Verification:** Ran the full test suite (`pytest`) successfully. The code formatter (`black`) was also run and no formatting issues were detected. 
✨ **Result:** A slightly cleaner and more maintainable map file with no change in functionality.

---
*PR created automatically by Jules for task [14553665212738276533](https://jules.google.com/task/14553665212738276533) started by @tsainez*