### PR TITLE
🧪 [Testing]: Add test for save_progress in campaign_manager.py

### DIFF
--- a/tests/unit/test_campaign_manager.py
+++ b/tests/unit/test_campaign_manager.py
@@ -3,13 +3,14 @@ from unittest.mock import patch
 
 from command_line_conflict.campaign_manager import CampaignManager
 
+
 class TestCampaignManager(unittest.TestCase):
     def setUp(self):
         # Prevent accessing user data dir and migrating
         self.patcher = patch("command_line_conflict.campaign_manager.get_user_data_dir")
         self.mock_get_dir = self.patcher.start()
         # Mock load_progress to prevent reading
-        self.load_patcher = patch.object(CampaignManager, 'load_progress')
+        self.load_patcher = patch.object(CampaignManager, "load_progress")
         self.mock_load = self.load_patcher.start()
 
     def tearDown(self):

--- a/tests/unit/test_campaign_manager.py
+++ b/tests/unit/test_campaign_manager.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import patch
+
+from command_line_conflict.campaign_manager import CampaignManager
+
+class TestCampaignManager(unittest.TestCase):
+    def setUp(self):
+        # Prevent accessing user data dir and migrating
+        self.patcher = patch("command_line_conflict.campaign_manager.get_user_data_dir")
+        self.mock_get_dir = self.patcher.start()
+        # Mock load_progress to prevent reading
+        self.load_patcher = patch.object(CampaignManager, 'load_progress')
+        self.mock_load = self.load_patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+        self.load_patcher.stop()
+
+    @patch("command_line_conflict.campaign_manager.atomic_save_json")
+    def test_save_progress_success(self, mock_atomic_save):
+        manager = CampaignManager("test_save.json")
+        manager.completed_missions = ["mission_1"]
+
+        manager.save_progress()
+
+        mock_atomic_save.assert_called_once_with("test_save.json", {"completed_missions": ["mission_1"]})
+
+    @patch("command_line_conflict.campaign_manager.atomic_save_json")
+    @patch("command_line_conflict.campaign_manager.log")
+    def test_save_progress_ioerror(self, mock_log, mock_atomic_save):
+        manager = CampaignManager("test_save.json")
+        manager.completed_missions = ["mission_1"]
+        mock_atomic_save.side_effect = IOError("Test IOError")
+
+        manager.save_progress()
+
+        mock_atomic_save.assert_called_once_with("test_save.json", {"completed_missions": ["mission_1"]})
+        mock_log.error.assert_called_once_with("Failed to save progress: Test IOError")


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the `save_progress` method in `CampaignManager`.
📊 **Coverage:** The new tests cover both the successful "happy path" (verifying `atomic_save_json` is called with correct data) and the error path (verifying `IOError` is handled and logged properly).
✨ **Result:** Improved test coverage and reliability for campaign progress saving mechanism.

---
*PR created automatically by Jules for task [6664474398241331793](https://jules.google.com/task/6664474398241331793) started by @tsainez*