### PR TITLE
🧹 Remove unused SimpleMap import in game scene

### DIFF
--- a/command_line_conflict/scenes/game.py
+++ b/command_line_conflict/scenes/game.py
@@ -17,7 +17,6 @@ from command_line_conflict.components.vision import Vision
 from command_line_conflict.fog_of_war import FogOfWar
 from command_line_conflict.game_state import GameState
 from command_line_conflict.logger import log
-from command_line_conflict.maps import SimpleMap  # noqa: F401  # pylint: disable=unused-import
 from command_line_conflict.maps.factory_battle_map import FactoryBattleMap
 from command_line_conflict.systems.ai_system import AISystem
 from command_line_conflict.systems.chat_system import ChatSystem

--- a/tests/unit/scenes/test_game_scene_camera.py
+++ b/tests/unit/scenes/test_game_scene_camera.py
@@ -15,13 +15,12 @@ class TestGameSceneCamera(unittest.TestCase):
 
         # Patch factories to avoid actual game state complexity
         with patch("command_line_conflict.scenes.game.factories"):
-            with patch("command_line_conflict.scenes.game.SimpleMap"):
-                with patch("command_line_conflict.scenes.game.FogOfWar"):
-                    with patch("command_line_conflict.scenes.game.RenderingSystem"):
-                        with patch("command_line_conflict.scenes.game.UISystem"):
-                            with patch("command_line_conflict.scenes.game.ChatSystem"):
-                                self.scene = GameScene(self.mock_game)
-                                self.scene.chat_system.handle_event.return_value = False
+            with patch("command_line_conflict.scenes.game.FogOfWar"):
+                with patch("command_line_conflict.scenes.game.RenderingSystem"):
+                    with patch("command_line_conflict.scenes.game.UISystem"):
+                        with patch("command_line_conflict.scenes.game.ChatSystem"):
+                            self.scene = GameScene(self.mock_game)
+                            self.scene.chat_system.handle_event.return_value = False
 
     def test_wasd_does_not_control_camera(self):
         # W key (Up) should NOT work


### PR DESCRIPTION
🎯 **What:** Removed unused `SimpleMap` import in `command_line_conflict/scenes/game.py` and updated unit tests mocking the removed import.
💡 **Why:** Reduces dead code, improves code readability, and satisfies linting requirements.
✅ **Verification:** Verified by running `black .` for formatting, `pylint command_line_conflict/scenes/game.py` to ensure no new errors, and `pytest tests/ --no-cov` to confirm all tests pass successfully.
✨ **Result:** A cleaner game scene module and up-to-date test suite without unused imports.

---
*PR created automatically by Jules for task [6252074570202763642](https://jules.google.com/task/6252074570202763642) started by @tsainez*