### PR TITLE
🧹 [Code Health] Remove unused annotations import in base map

### DIFF
--- a/command_line_conflict/maps/base.py
+++ b/command_line_conflict/maps/base.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 from heapq import heappop, heappush
 from typing import Dict, List, Tuple


### PR DESCRIPTION
🎯 **What:** Removed unused `from __future__ import annotations` import from `command_line_conflict/maps/base.py`.
💡 **Why:** The import is unreferenced and can be safely removed to improve code cleanliness and maintainability.
✅ **Verification:** Verified by running code formatting and lint checks (`black --check .`), as well as executing the full test suite (`pytest tests/ --no-cov`) to ensure no functional regressions were introduced.
✨ **Result:** Improved code health by removing dead code.

---
*PR created automatically by Jules for task [13769673167930841408](https://jules.google.com/task/13769673167930841408) started by @tsainez*