### PR TITLE
🧪 [Add missing error path test for music playback]

### DIFF
--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import patch
 
+import pygame
+
 from command_line_conflict.music import MusicManager
 
 
@@ -67,6 +69,17 @@ class TestMusicManager(unittest.TestCase):
 
         mock_music.load.assert_not_called()
         self.assertIsNone(manager.current_track)
+
+    @patch("command_line_conflict.music.log")
+    @patch("pygame.mixer.music")
+    @patch("pygame.mixer.init")
+    @patch("pygame.mixer.get_init", return_value=True)
+    @patch("os.path.exists", return_value=True)
+    def test_play_music_pygame_error(self, mock_exists, mock_get_init, mock_init, mock_music, mock_log):
+        manager = MusicManager()
+        mock_music.load.side_effect = pygame.error("Test error")
+        manager.play("test.ogg")
+        mock_log.error.assert_called_with("Failed to play music test.ogg: Test error")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing error path test for music playback in `music.py`.
📊 **Coverage:** The scenario where `pygame.mixer.music.load` raises a `pygame.error` is now tested.
✨ **Result:** The improvement in test coverage ensures the error is gracefully caught and logged.

---
*PR created automatically by Jules for task [3141491699078079236](https://jules.google.com/task/3141491699078079236) started by @tsainez*