### PR TITLE
🧪 Add error path test for save_progress in campaign_manager.py

### DIFF
--- a/tests/unit/test_campaign_manager.py
+++ b/tests/unit/test_campaign_manager.py
@@ -1,0 +1,15 @@
+import unittest
+from unittest.mock import patch
+
+from command_line_conflict.campaign_manager import CampaignManager
+
+
+class TestCampaignManager(unittest.TestCase):
+    @patch("command_line_conflict.campaign_manager.log")
+    @patch("command_line_conflict.campaign_manager.atomic_save_json")
+    def test_save_progress_io_error(self, mock_atomic_save, mock_log):
+        mock_atomic_save.side_effect = IOError("Disk full")
+        manager = CampaignManager(save_file="dummy.json")
+        manager.save_progress()
+        mock_log.error.assert_called_once()
+        self.assertIn("Failed to save progress: Disk full", mock_log.error.call_args[0][0])


### PR DESCRIPTION
* 🎯 **What:** The missing error path test for save_progress in campaign_manager.py when an IOError is raised.
* 📊 **Coverage:** The scenario where atomic_save_json throws an IOError.
* ✨ **Result:** Added the missing test case which increases test coverage for campaign_manager.py error handling.

---
*PR created automatically by Jules for task [7346497980666444050](https://jules.google.com/task/7346497980666444050) started by @tsainez*