### PR TITLE
🧪 Add error path test for pygame mixer initialization

### DIFF
--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import patch
 
+import pygame
+
 from command_line_conflict.music import MusicManager
 
 
@@ -67,6 +69,13 @@ class TestMusicManager(unittest.TestCase):
 
         mock_music.load.assert_not_called()
         self.assertIsNone(manager.current_track)
+
+    @patch("pygame.mixer.get_init", return_value=False)
+    @patch("pygame.mixer.init")
+    def test_init_mixer_failure(self, mock_init, mock_get_init):
+        mock_init.side_effect = pygame.error("Test error")
+        manager = MusicManager()
+        self.assertFalse(manager.enabled)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
*   🎯 **What:** Added a missing error path test for `pygame.mixer.init` in `music.py`.
*   📊 **Coverage:** Now tests the scenario where `pygame.mixer.init()` throws a `pygame.error`, verifying that `manager.enabled` is correctly set to `False`.
*   ✨ **Result:** Improved test coverage and reliability for error conditions during audio initialization.

---
*PR created automatically by Jules for task [5069087181666202266](https://jules.google.com/task/5069087181666202266) started by @tsainez*