### PR TITLE
🧹 Code Health: Refactor overly long find_path method

### DIFF
--- a/command_line_conflict/maps/base.py
+++ b/command_line_conflict/maps/base.py
@@ -149,61 +149,18 @@ class Map:
             cx, cy = current
             tentative_g = g_score[current] + 1
 
-            # Optimization: Unroll neighbor loop and explicitly inline neighbor
-            # checks to avoid tuple creation, iteration overhead, and reduce lookup costs
-
-            # Left neighbor
-            nx, ny = cx - 1, cy
-            if not (nx < 0 or nx >= width or ny < 0 or ny >= height):
-                if can_fly or (nx, ny) not in walls:
-                    if not eff_extra or (nx, ny) not in eff_extra:
-                        if tentative_g < g_score.get((nx, ny), inf):
-                            g_score[(nx, ny)] = tentative_g
-                            # Inline Manhattan distance for performance
-                            dx = nx - goal_x
-                            dy = ny - goal_y
-                            f = tentative_g + (dx if dx > 0 else -dx) + (dy if dy > 0 else -dy)
-                            heappush(open_set, (f, (nx, ny)))
-                            came_from[(nx, ny)] = current
-
-            # Right neighbor
-            nx, ny = cx + 1, cy
-            if not (nx < 0 or nx >= width or ny < 0 or ny >= height):
-                if can_fly or (nx, ny) not in walls:
-                    if not eff_extra or (nx, ny) not in eff_extra:
-                        if tentative_g < g_score.get((nx, ny), inf):
-                            g_score[(nx, ny)] = tentative_g
-                            dx = nx - goal_x
-                            dy = ny - goal_y
-                            f = tentative_g + (dx if dx > 0 else -dx) + (dy if dy > 0 else -dy)
-                            heappush(open_set, (f, (nx, ny)))
-                            came_from[(nx, ny)] = current
-
-            # Top neighbor
-            nx, ny = cx, cy - 1
-            if not (nx < 0 or nx >= width or ny < 0 or ny >= height):
-                if can_fly or (nx, ny) not in walls:
-                    if not eff_extra or (nx, ny) not in eff_extra:
-                        if tentative_g < g_score.get((nx, ny), inf):
-                            g_score[(nx, ny)] = tentative_g
-                            dx = nx - goal_x
-                            dy = ny - goal_y
-                            f = tentative_g + (dx if dx > 0 else -dx) + (dy if dy > 0 else -dy)
-                            heappush(open_set, (f, (nx, ny)))
-                            came_from[(nx, ny)] = current
-
-            # Bottom neighbor
-            nx, ny = cx, cy + 1
-            if not (nx < 0 or nx >= width or ny < 0 or ny >= height):
-                if can_fly or (nx, ny) not in walls:
-                    if not eff_extra or (nx, ny) not in eff_extra:
-                        if tentative_g < g_score.get((nx, ny), inf):
-                            g_score[(nx, ny)] = tentative_g
-                            dx = nx - goal_x
-                            dy = ny - goal_y
-                            f = tentative_g + (dx if dx > 0 else -dx) + (dy if dy > 0 else -dy)
-                            heappush(open_set, (f, (nx, ny)))
-                            came_from[(nx, ny)] = current
+            for dx_off, dy_off in ((-1, 0), (1, 0), (0, -1), (0, 1)):
+                nx, ny = cx + dx_off, cy + dy_off
+                if not (nx < 0 or nx >= width or ny < 0 or ny >= height):
+                    if can_fly or (nx, ny) not in walls:
+                        if not eff_extra or (nx, ny) not in eff_extra:
+                            if tentative_g < g_score.get((nx, ny), inf):
+                                g_score[(nx, ny)] = tentative_g
+                                dx = nx - goal_x
+                                dy = ny - goal_y
+                                f = tentative_g + (dx if dx > 0 else -dx) + (dy if dy > 0 else -dy)
+                                heappush(open_set, (f, (nx, ny)))
+                                came_from[(nx, ny)] = current
 
         return []
 


### PR DESCRIPTION
🎯 **What**
Refactored the overly long and complex `find_path` method in `command_line_conflict/maps/base.py` by replacing the massive, manually unrolled neighbor checking blocks (for left, right, top, and bottom) with a clean and concise `for` loop over coordinate offsets `((-1, 0), (1, 0), (0, -1), (0, 1))`.

💡 **Why**
The previous approach duplicated a significant amount of complex logic four times to achieve a marginal performance optimization. This caused the method to balloon in size and become a maintainability hazard (triggering pylint warnings for overly long methods). Consolidating the logic into a single loop makes the algorithm far easier to read, debug, and maintain, drastically improving code health without fundamentally altering the pathfinding behavior. 

✅ **Verification**
- Executed `pylint command_line_conflict/maps/base.py` which now scores a flawless 10.00/10, confirming the code health issue is fully resolved.
- Executed `pytest --no-cov`, running the full 263 unit tests, all of which passed, guaranteeing the core pathfinding functionality remains intact and no system-wide regressions were introduced.
- Passed Code Review, converting the loop iterable to a tuple instead of a list to mitigate per-loop allocation overhead.

✨ **Result**
A significantly cleaner, more concise A* implementation that is far easier to digest and maintain for future developers, achieving the core objective of improving codebase health.

---
*PR created automatically by Jules for task [16542998546540815854](https://jules.google.com/task/16542998546540815854) started by @tsainez*