### PR TITLE
🧹 Code Health: Extract shared event handling in end scenes

### DIFF
--- a/command_line_conflict/scenes/base.py
+++ b/command_line_conflict/scenes/base.py
@@ -1,0 +1,29 @@
+import pygame
+
+
+class BaseEndScene:
+    """Base class for endgame scenes to share common event handling."""
+
+    def __init__(self, game):
+        """Initializes the base end scene.
+
+        Args:
+            game: The main game object.
+        """
+        self.game = game
+        self.font = game.font
+        self.time = 0.0
+
+    def handle_event(self, event):
+        """Handles common events for the endgame scene.
+
+        Args:
+            event: The pygame event to handle.
+        """
+        if event.type == pygame.MOUSEMOTION:
+            pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
+        elif event.type == pygame.KEYDOWN:
+            if event.key in (pygame.K_RETURN, pygame.K_ESCAPE):
+                self.game.scene_manager.switch_to("menu")
+        elif event.type == pygame.MOUSEBUTTONDOWN:
+            self.game.scene_manager.switch_to("menu")

--- a/command_line_conflict/scenes/defeat.py
+++ b/command_line_conflict/scenes/defeat.py
@@ -1,34 +1,10 @@
 import math
 
-import pygame
+from .base import BaseEndScene
 
 
-class DefeatScene:
+class DefeatScene(BaseEndScene):
     """A scene to display when the player loses the game."""
-
-    def __init__(self, game):
-        """Initializes the DefeatScene.
-
-        Args:
-            game: The main game object.
-        """
-        self.game = game
-        self.font = game.font
-        self.time = 0.0
-
-    def handle_event(self, event):
-        """Handles events for the defeat scene.
-
-        Args:
-            event: The pygame event to handle.
-        """
-        if event.type == pygame.MOUSEMOTION:
-            pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
-        elif event.type == pygame.KEYDOWN:
-            if event.key in (pygame.K_RETURN, pygame.K_ESCAPE):
-                self.game.scene_manager.switch_to("menu")
-        elif event.type == pygame.MOUSEBUTTONDOWN:
-            self.game.scene_manager.switch_to("menu")
 
     def update(self, dt):
         """Updates the defeat scene.

--- a/command_line_conflict/scenes/victory.py
+++ b/command_line_conflict/scenes/victory.py
@@ -1,34 +1,10 @@
 import math
 
-import pygame
+from .base import BaseEndScene
 
 
-class VictoryScene:
+class VictoryScene(BaseEndScene):
     """A scene to display when the player wins the game."""
-
-    def __init__(self, game):
-        """Initializes the VictoryScene.
-
-        Args:
-            game: The main game object.
-        """
-        self.game = game
-        self.font = game.font
-        self.time = 0.0
-
-    def handle_event(self, event):
-        """Handles events for the victory scene.
-
-        Args:
-            event: The pygame event to handle.
-        """
-        if event.type == pygame.MOUSEMOTION:
-            pygame.mouse.set_cursor(pygame.SYSTEM_CURSOR_HAND)
-        elif event.type == pygame.KEYDOWN:
-            if event.key in (pygame.K_RETURN, pygame.K_ESCAPE):
-                self.game.scene_manager.switch_to("menu")
-        elif event.type == pygame.MOUSEBUTTONDOWN:
-            self.game.scene_manager.switch_to("menu")
 
     def update(self, dt):
         """Updates the victory scene.


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Created a new `BaseEndScene` in `command_line_conflict/scenes/base.py` and updated `DefeatScene` and `VictoryScene` to inherit from it, effectively extracting the duplicated `__init__` and `handle_event` methods. Also removed the now unused `pygame` imports in the child classes.

💡 **Why:** How this improves maintainability
Extracting duplicated event handling logic removes code duplication across end-game scenes, making future event handling changes easier as they only need to be applied in one central place (`BaseEndScene`). This reduces the chance of drift and enhances code readability.

✅ **Verification:** How you confirmed the change is safe
Ran `black` and `pylint` successfully on the updated files to verify formatting and linting. Ran the full test suite via `pytest` to ensure game functionality remains intact and no new errors are introduced.

✨ **Result:** The improvement achieved
Reduced lines of code in both `defeat.py` and `victory.py`, centralizing mouse/keyboard interaction logic into `base.py` for end scenes.

---
*PR created automatically by Jules for task [18024872264006706457](https://jules.google.com/task/18024872264006706457) started by @tsainez*