### PR TITLE
🛡️ Sentinel: [HIGH] Enforce .json extension when loading maps

### DIFF
--- a/command_line_conflict/maps/base.py
+++ b/command_line_conflict/maps/base.py
@@ -365,6 +365,11 @@ class Map:
         # Resolve symlinks to ensure we check the actual destination
         abs_path = os.path.realpath(filename)
 
+        # Security fix: Enforce .json extension to prevent reading arbitrary files
+        if not abs_path.lower().endswith(".json"):
+            log.error(f"Security violation: Invalid file extension for map load: {abs_path}")
+            raise ValueError("Map files must have a .json extension.")
+
         # Define allowed directories
         # 1. The maps directory (where this file resides)
         maps_dir = os.path.realpath(os.path.dirname(os.path.abspath(__file__)))

--- a/patch_load.py
+++ b/patch_load.py
@@ -1,0 +1,2 @@
+def replace():
+    pass

--- a/tests/security/test_map_extension_enforcement.py
+++ b/tests/security/test_map_extension_enforcement.py
@@ -40,3 +40,15 @@ def test_save_map_valid_extension(tmp_path):
     except ValueError as e:
         assert "Map files must have a .json extension" not in str(e)
         # It likely failed with "Cannot save to unauthorized location" or similar
+
+
+def test_load_map_invalid_extension():
+    """Verify that loading a map with a non-json extension raises a ValueError."""
+    with pytest.raises(ValueError, match="Map files must have a .json extension"):
+        Map.load_from_file("test_map.py")
+
+    with pytest.raises(ValueError, match="Map files must have a .json extension"):
+        Map.load_from_file("test_map.txt")
+
+    with pytest.raises(ValueError, match="Map files must have a .json extension"):
+        Map.load_from_file("test_map")

--- a/tests/security/test_map_load_traversal.py
+++ b/tests/security/test_map_load_traversal.py
@@ -12,9 +12,9 @@ class TestMapLoadTraversal(unittest.TestCase):
     def test_load_from_unauthorized_location(self, mock_realpath, mock_stat, mock_open, mock_json_load):
         """Verify that loading map from unauthorized location raises ValueError."""
         # Setup mocks to simulate a valid file in an unauthorized location
-        unauthorized_path = "/etc/passwd"  # Example unauthorized path
+        unauthorized_path = "/etc/passwd.json"  # Example unauthorized path
 
-        # We mock realpath to just return the input, simulating it resolving to /etc/passwd
+        # We mock realpath to just return the input, simulating it resolving to /etc/passwd.json
         mock_realpath.side_effect = lambda x: x
 
         # Mock stat to look like a regular small file

--- a/tests/security/test_map_security.py
+++ b/tests/security/test_map_security.py
@@ -135,7 +135,7 @@ class TestMapSecurity(unittest.TestCase):
         mock_fstat.return_value = mock_st
 
         with self.assertRaises(ValueError) as cm:
-            Map.load_from_file("/dev/zero")
+            Map.load_from_file("/dev/zero.json")
 
         self.assertIn("must be a regular file", str(cm.exception))
 


### PR DESCRIPTION
I have implemented a `.json` file extension check within the `Map.load_from_file` method in `command_line_conflict/maps/base.py` to prevent reading arbitrary files. I also updated the `test_map_extension_enforcement.py` unit test to verify this enforcement for map loading, and fixed other security unit tests (`test_map_load_traversal.py`, `test_map_security.py`) to properly account for the new `.json` check so they can continue testing their respective security policies without being preempted. All pre-commit formatting, linting, and tests successfully pass.

---
*PR created automatically by Jules for task [2116939120086685207](https://jules.google.com/task/2116939120086685207) started by @tsainez*