### PR TITLE
🧹 Refactor duplicate title rendering and pulse calculation logic

### DIFF
--- a/command_line_conflict/scenes/menu.py
+++ b/command_line_conflict/scenes/menu.py
@@ -7,6 +7,7 @@ import pygame
 from command_line_conflict import config
 from command_line_conflict.campaign_manager import CampaignManager
 from command_line_conflict.systems.sound_system import SoundSystem
+from command_line_conflict.utils.ui_helpers import draw_title_and_get_pulse
 
 
 class MenuScene:
@@ -174,14 +175,7 @@ class MenuScene:
         screen.fill((0, 0, 0))
 
         title_text = self._get_text_surface("Command Line Conflict", (255, 255, 255), "title")
-        title_rect = title_text.get_rect(center=(self.game.screen.get_width() / 2, 100))
-        screen.blit(title_text, title_rect)
-
-        # Pulse calculation: varies between 0 and 1
-        pulse = (math.sin(self.time * 5) + 1) / 2
-        # Interpolate between dim yellow (150, 150, 0) and bright yellow (255, 255, 0)
-        yellow_val = 150 + int(105 * pulse)
-        pulse_color = (yellow_val, yellow_val, 0)
+        pulse_color = draw_title_and_get_pulse(screen, title_text, self.time)
 
         self.option_rects.clear()
         for i, option in enumerate(self.menu_options):

--- a/command_line_conflict/scenes/settings.py
+++ b/command_line_conflict/scenes/settings.py
@@ -6,6 +6,7 @@ import pygame
 
 from command_line_conflict import config
 from command_line_conflict.systems.sound_system import SoundSystem
+from command_line_conflict.utils.ui_helpers import draw_title_and_get_pulse
 
 from ..logger import log
 
@@ -218,14 +219,7 @@ class SettingsScene:
         screen.fill((0, 0, 0))
 
         title_text = self._get_text_surface("Settings", (255, 255, 255), "title")
-        title_rect = title_text.get_rect(center=(self.game.screen.get_width() / 2, 100))
-        screen.blit(title_text, title_rect)
-
-        # Pulse calculation: varies between 0 and 1
-        pulse = (math.sin(self.time * 5) + 1) / 2
-        # Interpolate between dim yellow (150, 150, 0) and bright yellow (255, 255, 0)
-        yellow_val = 150 + int(105 * pulse)
-        pulse_color = (yellow_val, yellow_val, 0)
+        pulse_color = draw_title_and_get_pulse(screen, title_text, self.time)
 
         self.option_rects.clear()
         for i, option in enumerate(self.settings_options):

--- a/command_line_conflict/utils/ui_helpers.py
+++ b/command_line_conflict/utils/ui_helpers.py
@@ -1,0 +1,34 @@
+import math
+from typing import Tuple
+
+import pygame
+
+
+def draw_title_and_get_pulse(
+    screen: pygame.Surface,
+    title_text: pygame.Surface,
+    time: float,
+    center_y: int = 100,
+) -> Tuple[int, int, int]:
+    """Draws a title text surface centered on the screen and returns a pulse color.
+
+    This helper encapsulates common title rendering and pulse calculation logic used
+    across various menu and setting screens.
+
+    Args:
+        screen: The pygame screen surface to draw on.
+        title_text: The pre-rendered title text surface.
+        time: The current scene time used for the pulse calculation.
+        center_y: The y-coordinate to center the title on.
+
+    Returns:
+        A tuple representing the calculated RGB pulse color.
+    """
+    title_rect = title_text.get_rect(center=(screen.get_width() / 2, center_y))
+    screen.blit(title_text, title_rect)
+
+    # Pulse calculation: varies between 0 and 1
+    pulse = (math.sin(time * 5) + 1) / 2
+    # Interpolate between dim yellow (150, 150, 0) and bright yellow (255, 255, 0)
+    yellow_val = 150 + int(105 * pulse)
+    return (yellow_val, yellow_val, 0)


### PR DESCRIPTION
🎯 **What:** Extracted duplicated logic for rendering scene titles and computing pulsing colors from `MenuScene` and `SettingsScene` into a reusable helper function `draw_title_and_get_pulse` in `command_line_conflict/utils/ui_helpers.py`.

💡 **Why:** Reduces duplicate code across the codebase, improving maintainability. Future changes to how titles are rendered or how the pulse color is calculated only need to be updated in one place.

✅ **Verification:** Ran `black`, `pylint`, and the full test suite (`pytest --no-cov`). Verified that the game menus render correctly and the tests pass.

✨ **Result:** Cleaned up `scenes/menu.py` and `scenes/settings.py` by relying on a shared UI utility function, improving code health without changing the game's behavior.

---
*PR created automatically by Jules for task [8975423535028004266](https://jules.google.com/task/8975423535028004266) started by @tsainez*