### PR TITLE
🧹 Refactor title rendering into shared BaseScene

### DIFF
--- a/command_line_conflict/scenes/base.py
+++ b/command_line_conflict/scenes/base.py
@@ -1,0 +1,29 @@
+import math
+from typing import Tuple
+
+import pygame
+
+
+class BaseScene:
+    """Base class for scenes providing common rendering logic."""
+
+    def _draw_pulsing_title(self, screen: pygame.Surface, title: str, time: float) -> Tuple[int, int, int]:
+        """Draws the scene title and calculates a pulsing color for options.
+
+        Args:
+            screen: The pygame screen surface to draw on.
+            title: The text for the scene title.
+            time: Current scene time, used to calculate the pulse.
+
+        Returns:
+            The calculated pulsing RGB color tuple (R, G, B).
+        """
+        title_text = self._get_text_surface(title, (255, 255, 255), "title")  # type: ignore
+        title_rect = title_text.get_rect(center=(self.game.screen.get_width() / 2, 100))  # type: ignore
+        screen.blit(title_text, title_rect)
+
+        # Pulse calculation: varies between 0 and 1
+        pulse = (math.sin(time * 5) + 1) / 2
+        # Interpolate between dim yellow (150, 150, 0) and bright yellow (255, 255, 0)
+        yellow_val = 150 + int(105 * pulse)
+        return (yellow_val, yellow_val, 0)

--- a/command_line_conflict/scenes/menu.py
+++ b/command_line_conflict/scenes/menu.py
@@ -1,5 +1,4 @@
 import functools
-import math
 from typing import cast
 
 import pygame
@@ -7,9 +6,10 @@ import pygame
 from command_line_conflict import config
 from command_line_conflict.campaign_manager import CampaignManager
 from command_line_conflict.systems.sound_system import SoundSystem
+from .base import BaseScene
 
 
-class MenuScene:
+class MenuScene(BaseScene):
     """Manages the main menu scene, allowing navigation to other scenes."""
 
     def __init__(self, game):
@@ -173,15 +173,7 @@ class MenuScene:
         """
         screen.fill((0, 0, 0))
 
-        title_text = self._get_text_surface("Command Line Conflict", (255, 255, 255), "title")
-        title_rect = title_text.get_rect(center=(self.game.screen.get_width() / 2, 100))
-        screen.blit(title_text, title_rect)
-
-        # Pulse calculation: varies between 0 and 1
-        pulse = (math.sin(self.time * 5) + 1) / 2
-        # Interpolate between dim yellow (150, 150, 0) and bright yellow (255, 255, 0)
-        yellow_val = 150 + int(105 * pulse)
-        pulse_color = (yellow_val, yellow_val, 0)
+        pulse_color = self._draw_pulsing_title(screen, "Command Line Conflict", self.time)
 
         self.option_rects.clear()
         for i, option in enumerate(self.menu_options):

--- a/command_line_conflict/scenes/settings.py
+++ b/command_line_conflict/scenes/settings.py
@@ -1,5 +1,4 @@
 import functools
-import math
 from typing import cast
 
 import pygame
@@ -8,9 +7,10 @@ from command_line_conflict import config
 from command_line_conflict.systems.sound_system import SoundSystem
 
 from ..logger import log
+from .base import BaseScene
 
 
-class SettingsScene:
+class SettingsScene(BaseScene):
     """Manages the settings menu, allowing players to change game options."""
 
     def __init__(self, game):
@@ -217,15 +217,7 @@ class SettingsScene:
         """
         screen.fill((0, 0, 0))
 
-        title_text = self._get_text_surface("Settings", (255, 255, 255), "title")
-        title_rect = title_text.get_rect(center=(self.game.screen.get_width() / 2, 100))
-        screen.blit(title_text, title_rect)
-
-        # Pulse calculation: varies between 0 and 1
-        pulse = (math.sin(self.time * 5) + 1) / 2
-        # Interpolate between dim yellow (150, 150, 0) and bright yellow (255, 255, 0)
-        yellow_val = 150 + int(105 * pulse)
-        pulse_color = (yellow_val, yellow_val, 0)
+        pulse_color = self._draw_pulsing_title(screen, "Settings", self.time)
 
         self.option_rects.clear()
         for i, option in enumerate(self.settings_options):


### PR DESCRIPTION
🎯 **What:** Extracted duplicated title rendering and pulse color calculation logic from `MenuScene` and `SettingsScene` into a shared `BaseScene` class (`command_line_conflict/scenes/base.py`). Removed unused `math` imports in both scenes.

💡 **Why:** The title drawing code and sine-wave pulse interpolation were identical across the menu and settings screens. Moving this to a common base class adheres to DRY principles, making future adjustments to scene headers centralized and easier to maintain.

✅ **Verification:** 
- Verified `BaseScene` implementation correctly handles the `pygame.Surface` extraction.
- Ran all scene unit tests using `pytest tests/unit/scenes/ --no-cov`, which passed successfully.
- Verified linting using `pylint` and formatting using `black` to ensure no system-wide regressions.

✨ **Result:** Reduced code duplication across the `command_line_conflict/scenes/` module, resulting in cleaner subclass implementations for `MenuScene` and `SettingsScene`.

---
*PR created automatically by Jules for task [13980058740749287568](https://jules.google.com/task/13980058740749287568) started by @tsainez*