### PR TITLE
🎨 Palette: Add chat UX improvements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -95,3 +95,6 @@
 ## 2026-05-25 - Rapid Pagination Support in FileDialog
 **Learning:** For scrollable lists that can grow significantly (like save files or levels), standard arrow-key navigation (up/down one item at a time) becomes tedious and a barrier to efficient keyboard navigation.
 **Action:** When implementing or enhancing scrollable UI components, always support rapid pagination using `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN`. Calculate the pagination jump size logically based on the visible view bounds (e.g., jump by `max_visible_files`) and ensure helper text is updated to clearly communicate this capability to the user.
+## 2026-07-24 - Exposing Undiscoverable Keybinds and Empty States
+**Learning:** Hardcoded keyboard shortcuts and toggles (like the L key for the chat log) often remain undiscoverable to users without on-screen guidance. Additionally, opening a toggled UI view (like a chat log) that is completely blank leaves the user confused about whether the UI failed to load or is just empty.
+**Action:** Always add explicit on-screen UI hints for non-obvious keyboard shortcuts (like chat toggles). For dynamic lists or logs that can be toggled open, always implement an explicit "empty state" message (e.g., "Chat log is empty") to assure the user the UI is functioning correctly.

--- a/command_line_conflict/systems/chat_system.py
+++ b/command_line_conflict/systems/chat_system.py
@@ -170,7 +170,10 @@ class ChatSystem:
             # If explicit log view is active, draw a background
             if self.show_log:
                 # Calculate height based on max messages or current messages
-                height = min(len(self.messages), self.max_messages) * line_height + 10
+                if not self.messages:
+                    height = line_height + 10
+                else:
+                    height = min(len(self.messages), self.max_messages) * line_height + 10
                 bg_rect = pygame.Rect(5, chat_bottom - height, 600, height)
                 s = pygame.Surface((bg_rect.width, bg_rect.height), pygame.SRCALPHA)
                 s.fill((0, 0, 0, 160))  # Semi-transparent black
@@ -179,6 +182,17 @@ class ChatSystem:
             # The transient overlay only shows the newest few lines; the L
             # log toggle shows everything with a backdrop.
             visible = self.messages if self.show_log else self.messages[-self.max_visible_messages :]
+
+            if self.show_log and not self.messages:
+                # Empty state message
+                empty_text = "Chat log is empty."
+                text_surface = self.message_font.render(empty_text, True, (150, 150, 150))
+                shadow_surface = self.message_font.render(empty_text, True, (0, 0, 0))
+                y_pos = chat_bottom - line_height
+                if self.input_active:
+                    y_pos -= line_height + 5
+                self.screen.blit(shadow_surface, (12, y_pos + 2))
+                self.screen.blit(text_surface, (10, y_pos))
 
             for i, msg in enumerate(reversed(visible)):
                 text_surface = msg.get("surface")

--- a/command_line_conflict/systems/ui_system.py
+++ b/command_line_conflict/systems/ui_system.py
@@ -45,6 +45,8 @@ class UISystem:
             "H: Hold Position",
             "P / Space: Pause",
             "Cam: Arrows / Drag",
+            "Enter: Chat",
+            "L: Chat Log",
             "ESC: Menu",
         ]
 

--- a/tests/test_ux_improvements.py
+++ b/tests/test_ux_improvements.py
@@ -28,6 +28,8 @@ def test_ui_system_help_text_content():
         "H: Hold Position",
         "P / Space: Pause",
         "Cam: Arrows / Drag",
+        "Enter: Chat",
+        "L: Chat Log",
         "ESC: Menu",
     ]
 


### PR DESCRIPTION
💡 What: Added chat keyboard shortcut hints to the on-screen display and implemented an empty state for the chat log.
🎯 Why: Players had no way to know that pressing 'Enter' opens chat or 'L' opens the chat log without reading the source code. Furthermore, toggling an empty chat log previously rendered a blank box, creating confusion.
📸 Before/After: Not applicable (ASCII/Pygame UI overlay change)
♿ Accessibility: Improves discoverability of chat features and provides clearer UI context for empty states.

---
*PR created automatically by Jules for task [2272824400248429400](https://jules.google.com/task/2272824400248429400) started by @tsainez*