### PR TITLE
🎨 Palette: Add placeholder text to empty chat input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -95,3 +95,6 @@
 ## 2026-05-25 - Rapid Pagination Support in FileDialog
 **Learning:** For scrollable lists that can grow significantly (like save files or levels), standard arrow-key navigation (up/down one item at a time) becomes tedious and a barrier to efficient keyboard navigation.
 **Action:** When implementing or enhancing scrollable UI components, always support rapid pagination using `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN`. Calculate the pagination jump size logically based on the visible view bounds (e.g., jump by `max_visible_files`) and ensure helper text is updated to clearly communicate this capability to the user.
+## 2026-05-25 - Placeholder Text for Empty Inputs
+**Learning:** Pygame's basic input rendering often omits placeholder text, leaving empty text fields visually confusing and making it unclear what input is expected or what keyboard controls are active (e.g. Chat System).
+**Action:** Always render a distinct placeholder string using a subdued color (e.g., `(150, 150, 150)`) when `input_text` is empty to guide the user on context and controls.

--- a/command_line_conflict/systems/chat_system.py
+++ b/command_line_conflict/systems/chat_system.py
@@ -207,9 +207,15 @@ class ChatSystem:
             pygame.draw.rect(self.screen, (100, 100, 100), input_bg_rect, 1)
 
             # Draw text
-            display_text = f"Chat: {self.input_text}"
+            if self.input_text:
+                display_text = f"Chat: {self.input_text}"
+                color = (255, 255, 255)
+            else:
+                display_text = "Chat: Type message... (Enter to send, Esc to cancel)"
+                color = (150, 150, 150)
+
             if self.cursor_visible:
                 display_text += "_"
 
-            text_surface = self.font.render(display_text, True, (255, 255, 255))
+            text_surface = self.font.render(display_text, True, color)
             self.screen.blit(text_surface, (10, input_y))


### PR DESCRIPTION
💡 What: Added a placeholder text to the chat input when it is empty.
🎯 Why: It provides helpful guidance to the user about what to type and the available keyboard shortcuts (Enter to send, Esc to cancel).
📸 Before/After: N/A
♿ Accessibility: Improves cognitive accessibility by explicitly stating the expected input and available actions, reducing memory load.

---
*PR created automatically by Jules for task [4816846340011253391](https://jules.google.com/task/4816846340011253391) started by @tsainez*