### PR TITLE
🎨 Palette: Improve tooltip unit name formatting

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -95,3 +95,7 @@
 ## 2026-05-25 - Rapid Pagination Support in FileDialog
 **Learning:** For scrollable lists that can grow significantly (like save files or levels), standard arrow-key navigation (up/down one item at a time) becomes tedious and a barrier to efficient keyboard navigation.
 **Action:** When implementing or enhancing scrollable UI components, always support rapid pagination using `pygame.K_PAGEUP` and `pygame.K_PAGEDOWN`. Calculate the pagination jump size logically based on the visible view bounds (e.g., jump by `max_visible_files`) and ensure helper text is updated to clearly communicate this capability to the user.
+
+## 2026-07-25 - Clarity over Brevity in Unit Info Tooltips
+**Learning:** Using raw internal identifiers (e.g., "Rover_Factory") in UI tooltips increases cognitive load and creates an unpolished experience compared to well-formatted display names.
+**Action:** Always format internal string identifiers for user-facing UI elements by replacing underscores with spaces and applying title case (e.g., `identity.name.replace("_", " ").title()`) to ensure human-readable text.

--- a/command_line_conflict/systems/ui_system.py
+++ b/command_line_conflict/systems/ui_system.py
@@ -674,7 +674,7 @@ class UISystem:
         if not identity:
             return
 
-        lines = [identity.name.title()]
+        lines = [identity.name.replace("_", " ").title()]
         if health:
             lines.append(f"HP: {int(health.hp)}/{health.max_hp}")
         if player:


### PR DESCRIPTION
💡 What: Replace internal underscores with spaces and format with title case for entity names in tooltips.
🎯 Why: Using raw internal identifiers (like "Rover_Factory") increases cognitive load. Replacing underscores with spaces aligns with the guidance for clarity over brevity in unit info, making the interface more pleasant to use.
📸 Before/After: Before: "Rover_Factory". After: "Rover Factory"
♿ Accessibility: Improves readability and reduces cognitive load by presenting human-readable text.

---
*PR created automatically by Jules for task [12922707858608259507](https://jules.google.com/task/12922707858608259507) started by @tsainez*